### PR TITLE
Deploy to S3

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -32,11 +32,14 @@ jobs:
       - name: Package with Gradle (no test)
         run: |
           ./gradlew --stacktrace --info packageApp -x test
+      - name: Remove files that should not be saved
+        run: |
+          find build/distributions -not -name "gazeplay-project-*.zip"
       - name: Save Package Job Artifacts
         uses: actions/upload-artifact@v1
         with:
           name: package-artifacts
-          path: build/distributions/gazeplay-project-*.zip
+          path: build/distributions/
 
   deploy:
     needs: package

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -4,19 +4,51 @@ name: Java CI
 on: [push, pull_request]
 
 jobs:
+
   build:
-
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v1
-    - name: Set up JDK 11
-      uses: actions/setup-java@v1
-      with:
-        java-version: 11
-    - name: Set up xvfb for non headless tests
-      run: sudo apt-get install xvfb
-    - name: Build with Gradle (no test)
-      run: ./gradlew --stacktrace --info build -x test
-    - name: Run tests with Gradle
-      run: xvfb-run --auto-servernum ./gradlew --stacktrace --info test
+      - uses: actions/checkout@v1
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Set up xvfb for non headless tests
+        run: sudo apt-get install xvfb
+      - name: Build with Gradle (no test)
+        run: ./gradlew --stacktrace --info build -x test
+      - name: Run tests with Gradle
+        run: xvfb-run --auto-servernum ./gradlew --stacktrace --info test
+
+  package:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Package with Gradle (no test)
+        run: |
+          ./gradlew --stacktrace --info packageApp -x test
+      - name: Save Package Job Artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: package-artifacts
+          path: build/distributions/gazeplay-project-*.zip
+
+  deploy:
+    needs: package
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get Package Job Artifacts
+        uses: actions/download-artifact@v1
+        with:
+          name: package-artifacts
+      - name: Upload to S3
+        uses: jakejarvis/s3-sync-action@master
+        with:
+          args: --acl public-read
+        env:
+          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: 'eu-west-3'                # optional: defaults to us-east-1
+          SOURCE_DIR: 'build-artifacts'          # optional: defaults to entire repository
+          DEST_DIR: 'snapshots'

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -34,7 +34,7 @@ jobs:
           ./gradlew --stacktrace --info packageApp -x test
       - name: Remove files that should not be saved
         run: |
-          find build/distributions -not -name "gazeplay-project-*.zip"
+          find build/distributions/ -type f -not -name "gazeplay-project-*.zip" -delete
       - name: Save Package Job Artifacts
         uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -13,10 +13,10 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 11
-      - name: Set up xvfb for non headless tests
-        run: sudo apt-get install xvfb
       - name: Build with Gradle (no test)
         run: ./gradlew --stacktrace --info build -x test
+      - name: Set up xvfb for non headless tests
+        run: sudo apt-get install xvfb
       - name: Run tests with Gradle
         run: xvfb-run --auto-servernum ./gradlew --stacktrace --info test
 
@@ -24,6 +24,11 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v1
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
       - name: Package with Gradle (no test)
         run: |
           ./gradlew --stacktrace --info packageApp -x test


### PR DESCRIPTION
Use GitHub Actions workflow to package the project and push it to an Amazon S3 bucket.

So that snapshots can be downloaded and used ASAP by testers and users.
