### PR TITLE
Upgrade Gradle Wrapper to v6.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,6 @@ plugins {
     id 'net.researchgate.release' version '2.6.0'
     id 'org.beryx.runtime' version '1.3.0'
 
-    id 'com.gradle.build-scan' version '2.0.2'
     id 'org.springframework.boot' version '2.2.1.RELEASE'
     id 'io.spring.dependency-management' version '1.0.8.RELEASE'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Sat Sep 07 12:13:32 BST 2019
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id "com.gradle.enterprise" version "3.1.1"
+}
+
 rootProject.name = 'gazeplay-project'
 include(':gazeplay-commons')
 include(':gazeplay-games-commons')


### PR DESCRIPTION
There are a number of QoL upgrades in Gradle 6, as explained in the [release notes](https://docs.gradle.org/current/release-notes.html).