### PR TITLE
Changing the Backgound Music for games

### DIFF
--- a/gazeplay-commons/src/main/java/net/gazeplay/commons/configuration/Configuration.java
+++ b/gazeplay-commons/src/main/java/net/gazeplay/commons/configuration/Configuration.java
@@ -79,6 +79,7 @@ public class Configuration {
     private static final boolean DEFAULT_VALUE_FIXATIONSEQUENCE_DISABLED = false;
     public static final double DEFAULT_VALUE_MUSIC_VOLUME = 0.25d;
     public static final String DEFAULT_VALUE_MUSIC_FOLDER = "";
+    public static final String DEFAULT_VALUE_BACKGROUND_MUSIC = "songidea(copycat)_0.mp3";
     private static final Double DEFAULT_VALUE_EFFECTS_VOLUME = DEFAULT_VALUE_MUSIC_VOLUME;
 
     private static final boolean DEFAULT_VALUE_GAZE_MENU = false;

--- a/gazeplay-commons/src/test/java/net/gazeplay/commons/utils/games/BackgroundMusicManagerTest.java
+++ b/gazeplay-commons/src/test/java/net/gazeplay/commons/utils/games/BackgroundMusicManagerTest.java
@@ -8,16 +8,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
 import org.testfx.framework.junit5.ApplicationExtension;
 
 import java.io.File;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 @ExtendWith(ApplicationExtension.class)
-@RunWith(MockitoJUnitRunner.class)
 class BackgroundMusicManagerTest {
 
     private BackgroundMusicManager musicManager = BackgroundMusicManager.getInstance();
@@ -43,7 +40,7 @@ class BackgroundMusicManagerTest {
 
     @AfterEach
     void teardown() {
-        musicManager.getCurrentMusic().setVolume(previousVolume);
+        if (musicManager.getCurrentMusic() != null) musicManager.getCurrentMusic().setVolume(previousVolume);
     }
 
     @Test
@@ -76,5 +73,49 @@ class BackgroundMusicManagerTest {
     @ValueSource(doubles = {-0.1, 100, 1.1})
     void shouldNotSetTheVolume(double volume) {
         assertThrows(IllegalArgumentException.class, () -> musicManager.setVolume(volume));
+    }
+
+    @Test
+    void shouldBackupAndRestorePlaylist() {
+        int numberOfTracks = musicManager.getPlaylist().size();
+        musicManager.backupPlaylist();
+        musicManager.emptyPlaylist();
+        musicManager.restorePlaylist();
+        assertEquals(numberOfTracks, musicManager.getPlaylist().size());
+    }
+
+    @Test
+    void shouldNotBackupOrRestoreEmptyPlaylist() {
+        int numberOfTracks = musicManager.getPlaylist().size();
+        musicManager.emptyPlaylist();
+
+        musicManager.backupPlaylist();
+        musicManager.restorePlaylist();
+
+        assertNotEquals(numberOfTracks, musicManager.getPlaylist().size());
+    }
+
+    @Test
+    void shouldOnlyBackupThePlaylistOnce() {
+        int numberOfTracks = musicManager.getPlaylist().size();
+        musicManager.backupPlaylist();
+        musicManager.backupPlaylist();
+
+        musicManager.emptyPlaylist();
+
+        musicManager.restorePlaylist();
+        assertEquals(numberOfTracks, musicManager.getPlaylist().size());
+    }
+
+    @Test
+    void shouldOnlyRestoreThePlaylistOnce() {
+        int numberOfTracks = musicManager.getPlaylist().size();
+        musicManager.backupPlaylist();
+
+        musicManager.emptyPlaylist();
+
+        musicManager.restorePlaylist();
+        musicManager.restorePlaylist();
+        assertEquals(numberOfTracks, musicManager.getPlaylist().size());
     }
 }

--- a/gazeplay/src/main/java/net/gazeplay/commons/utils/stats/StatsDisplay.java
+++ b/gazeplay/src/main/java/net/gazeplay/commons/utils/stats/StatsDisplay.java
@@ -15,10 +15,11 @@ import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
 import lombok.extern.slf4j.Slf4j;
 import net.gazeplay.GazePlay;
-import net.gazeplay.ui.scenes.stats.StatsContext;
 import net.gazeplay.commons.utils.FixationPoint;
 import net.gazeplay.commons.utils.HomeButton;
+import net.gazeplay.commons.utils.games.BackgroundMusicManager;
 import net.gazeplay.stats.ShootGamesStats;
+import net.gazeplay.ui.scenes.stats.StatsContext;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -29,22 +30,22 @@ public class StatsDisplay {
 
     public static HomeButton createHomeButtonInStatsScreen(GazePlay gazePlay, StatsContext statsContext) {
 
-        EventHandler<Event> homeEvent = e -> {
-
-            // if (e.getEventType() == MouseEvent.MOUSE_CLICKED) {
-
-            statsContext.getRoot().setCursor(Cursor.WAIT); // Change cursor to wait style
-
-            gazePlay.onReturnToMenu();
-
-            statsContext.getRoot().setCursor(Cursor.DEFAULT); // Change cursor to default style
-            // }
-        };
+        EventHandler<Event> homeEvent = e -> returnToMenu(gazePlay, statsContext);
 
         HomeButton homeButton = new HomeButton();
         homeButton.addEventHandler(MouseEvent.MOUSE_CLICKED, homeEvent);
 
         return homeButton;
+    }
+
+    static void returnToMenu(GazePlay gazePlay, StatsContext statsContext) {
+        statsContext.getRoot().setCursor(Cursor.WAIT); // Change cursor to wait style
+
+        BackgroundMusicManager.getInstance().restorePlaylist();
+        BackgroundMusicManager.getInstance().previous();
+        gazePlay.onReturnToMenu();
+
+        statsContext.getRoot().setCursor(Cursor.DEFAULT); // Change cursor to default style
     }
 
     public static LineChart<String, Number> buildLineChart(Stats stats, final Region root) {

--- a/gazeplay/src/main/java/net/gazeplay/ui/scenes/configuration/ConfigurationContext.java
+++ b/gazeplay/src/main/java/net/gazeplay/ui/scenes/configuration/ConfigurationContext.java
@@ -943,7 +943,7 @@ public class ConfigurationContext extends GraphicalContext<BorderPane> {
             File gazePlayFolder = GazePlayDirectories.getGazePlayFolder();
             File gazePlayMusicFolder = new File(gazePlayFolder, "music");
 
-            String songName = "songidea(copycat)_0.mp3";
+            String songName = Configuration.DEFAULT_VALUE_BACKGROUND_MUSIC;
             setupNewMusicFolder(gazePlayMusicFolder, songName);
 
             musicFolder = gazePlayMusicFolder.getAbsolutePath();

--- a/gazeplay/src/main/java/net/gazeplay/ui/scenes/configuration/ConfigurationContext.java
+++ b/gazeplay/src/main/java/net/gazeplay/ui/scenes/configuration/ConfigurationContext.java
@@ -935,7 +935,7 @@ public class ConfigurationContext extends GraphicalContext<BorderPane> {
         return pane;
     }
 
-    private static void changeMusicFolder(final String newMusicFolder, Configuration config) {
+    static void changeMusicFolder(final String newMusicFolder, Configuration config) {
 
         String musicFolder = newMusicFolder;
 

--- a/gazeplay/src/main/java/net/gazeplay/ui/scenes/gamemenu/GameMenuController.java
+++ b/gazeplay/src/main/java/net/gazeplay/ui/scenes/gamemenu/GameMenuController.java
@@ -8,6 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 import net.gazeplay.GameLifeCycle;
 import net.gazeplay.GameSpec;
 import net.gazeplay.GazePlay;
+import net.gazeplay.commons.configuration.Configuration;
 import net.gazeplay.commons.utils.games.BackgroundMusicManager;
 import net.gazeplay.commons.utils.stats.Stats;
 import net.gazeplay.ui.scenes.ingame.GameContext;
@@ -84,8 +85,9 @@ public class GameMenuController {
         if (selectedGameSpec.getGameSummary().getBackgroundMusicUrl() != null) {
 
             final BackgroundMusicManager musicManager = BackgroundMusicManager.getInstance();
-            log.info("is default music set : {}", musicManager.getIsCustomMusicSet().getValue());
-            if (!musicManager.getIsCustomMusicSet().getValue() || musicManager.getPlaylist().isEmpty()) {
+            boolean defaultMusicPlaying = musicManager.getCurrentMusic().getMedia().getSource().contains(Configuration.DEFAULT_VALUE_BACKGROUND_MUSIC);
+            log.info("is default music set : {}", defaultMusicPlaying);
+            if (defaultMusicPlaying || musicManager.getPlaylist().isEmpty()) {
                 musicManager.emptyPlaylist();
                 musicManager.playMusicAlone(selectedGameSpec.getGameSummary().getBackgroundMusicUrl());
                 gameContext.getMusicControl().updateMusicController();

--- a/gazeplay/src/main/java/net/gazeplay/ui/scenes/gamemenu/GameMenuController.java
+++ b/gazeplay/src/main/java/net/gazeplay/ui/scenes/gamemenu/GameMenuController.java
@@ -68,14 +68,6 @@ public class GameMenuController {
         final Scene scene = gazePlay.getPrimaryScene();
         final Stats stats = gameLauncher.createNewStats(scene);
 
-        // if (config.isHeatMapDisabled()) {
-        // log.info("HeatMap is disabled, skipping instantiation of the HeatMap Data model");
-        // } else {
-        // // gameContext.getGazeDeviceManager().addGazeMotionListener(stats);
-        // }
-
-        // gameContext.getGazeDeviceManager().addGazeMotionListener(secondScreen);
-
         GameLifeCycle currentGame = gameLauncher.createNewGame(gameContext, gameVariant, stats);
 
         gameContext.createControlPanel(gazePlay, stats, currentGame);
@@ -83,19 +75,24 @@ public class GameMenuController {
         gameContext.createQuitShortcut(gazePlay, stats, currentGame);
 
         if (selectedGameSpec.getGameSummary().getBackgroundMusicUrl() != null) {
-
             final BackgroundMusicManager musicManager = BackgroundMusicManager.getInstance();
-            boolean defaultMusicPlaying = musicManager.getCurrentMusic().getMedia().getSource().contains(Configuration.DEFAULT_VALUE_BACKGROUND_MUSIC);
-            log.info("is default music set : {}", defaultMusicPlaying);
-            if (defaultMusicPlaying || musicManager.getPlaylist().isEmpty()) {
-                musicManager.emptyPlaylist();
-                musicManager.playMusicAlone(selectedGameSpec.getGameSummary().getBackgroundMusicUrl());
-                gameContext.getMusicControl().updateMusicController();
-            }
+            playBackgroundMusic(gameContext, selectedGameSpec, musicManager);
         }
 
         stats.start();
         currentGame.launch();
+    }
+
+    void playBackgroundMusic(GameContext gameContext, GameSpec selectedGameSpec, BackgroundMusicManager musicManager) {
+        boolean defaultMusicPlaying = musicManager.getCurrentMusic().getMedia().getSource().contains(Configuration.DEFAULT_VALUE_BACKGROUND_MUSIC);
+        log.info("is default music set : {}", defaultMusicPlaying);
+
+        if (defaultMusicPlaying || musicManager.getPlaylist().isEmpty()) {
+            musicManager.backupPlaylist();
+            musicManager.emptyPlaylist();
+            musicManager.playMusicAlone(selectedGameSpec.getGameSummary().getBackgroundMusicUrl());
+            gameContext.getMusicControl().updateMusicController();
+        }
     }
 
 }

--- a/gazeplay/src/test/java/net/gazeplay/commons/utils/stats/StatsDisplayTest.java
+++ b/gazeplay/src/test/java/net/gazeplay/commons/utils/stats/StatsDisplayTest.java
@@ -1,0 +1,55 @@
+package net.gazeplay.commons.utils.stats;
+
+import javafx.scene.Cursor;
+import net.gazeplay.GazePlay;
+import net.gazeplay.commons.utils.HomeButton;
+import net.gazeplay.ui.scenes.stats.StatsContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.runner.RunWith;
+import org.mockito.*;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.testfx.framework.junit5.ApplicationExtension;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(ApplicationExtension.class)
+@RunWith(MockitoJUnitRunner.class)
+class StatsDisplayTest {
+
+    @Mock
+    private GazePlay mockGazePlay;
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private StatsContext mockStatsContext;
+
+    @Captor
+    private ArgumentCaptor<Cursor> captor;
+
+    @BeforeEach
+    void setup() {
+        initMocks();
+    }
+
+    void initMocks() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    void shouldCreateHomeButton() {
+        HomeButton button = StatsDisplay.createHomeButtonInStatsScreen(mockGazePlay, mockStatsContext);
+        assert button.isVisible();
+    }
+
+    @Test
+    void shouldSetTheCursorWhenPressed() {
+        StatsDisplay.returnToMenu(mockGazePlay, mockStatsContext);
+
+        verify(mockStatsContext.getRoot(), times(2)).setCursor(captor.capture());
+        assertTrue(captor.getAllValues().contains(Cursor.WAIT));
+        assertTrue(captor.getAllValues().contains(Cursor.DEFAULT));
+    }
+}

--- a/gazeplay/src/test/java/net/gazeplay/ui/scenes/configuration/ConfigurationContextMusicTest.java
+++ b/gazeplay/src/test/java/net/gazeplay/ui/scenes/configuration/ConfigurationContextMusicTest.java
@@ -1,0 +1,53 @@
+package net.gazeplay.ui.scenes.configuration;
+
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
+import net.gazeplay.commons.configuration.Configuration;
+import net.gazeplay.commons.utils.games.GazePlayDirectories;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.testfx.framework.junit5.ApplicationExtension;
+
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(ApplicationExtension.class)
+@RunWith(MockitoJUnitRunner.class)
+class ConfigurationContextMusicTest {
+
+    @Mock
+    private Configuration mockConfig;
+
+    @BeforeEach
+    void setup() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    void canChangeMusicFolderToNewFolder() {
+        StringProperty musicFolder = new SimpleStringProperty();
+        String newFolder = "new/folder";
+        when(mockConfig.getMusicFolderProperty()).thenReturn(musicFolder);
+        ConfigurationContext.changeMusicFolder(newFolder, mockConfig);
+
+        assertEquals(musicFolder.getValue(), newFolder);
+    }
+
+    @Test
+    void canChangeMusicFolderToDefaultFolder() {
+        StringProperty musicFolder = new SimpleStringProperty();
+        String newFolder = "";
+        String expectedFolder = GazePlayDirectories.getGazePlayFolder() + File.separator + "music";
+        when(mockConfig.getMusicFolderProperty()).thenReturn(musicFolder);
+        ConfigurationContext.changeMusicFolder(newFolder, mockConfig);
+
+        assertEquals(musicFolder.getValue(), expectedFolder);
+    }
+}

--- a/gazeplay/src/test/java/net/gazeplay/ui/scenes/gamemenu/GameMenuControllerTest.java
+++ b/gazeplay/src/test/java/net/gazeplay/ui/scenes/gamemenu/GameMenuControllerTest.java
@@ -1,0 +1,74 @@
+package net.gazeplay.ui.scenes.gamemenu;
+
+import net.gazeplay.GameSpec;
+import net.gazeplay.GameSummary;
+import net.gazeplay.commons.utils.games.BackgroundMusicManager;
+import net.gazeplay.ui.MusicControl;
+import net.gazeplay.ui.scenes.ingame.GameContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.runner.RunWith;
+import org.mockito.Answers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.testfx.framework.junit5.ApplicationExtension;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(ApplicationExtension.class)
+@RunWith(MockitoJUnitRunner.class)
+class GameMenuControllerTest {
+
+    @InjectMocks
+    private GameMenuController gameMenuController;
+
+    @Mock
+    private GameContext mockGameContext;
+
+    @Mock
+    private GameSpec mockGameSpec;
+
+    @Mock
+    private GameSummary mockGameSummary;
+
+    @Mock
+    private MusicControl mockMusicControl;
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private BackgroundMusicManager mockMusicManager;
+
+    @BeforeEach
+    void setup() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    void shouldSetBackgroundMusic() {
+        when(mockMusicManager.getCurrentMusic().getMedia().getSource()).thenReturn("songidea(copycat)_0.mp3");
+        when(mockMusicManager.getPlaylist().isEmpty()).thenReturn(false);
+
+        when(mockGameSpec.getGameSummary()).thenReturn(mockGameSummary);
+        when(mockGameSummary.getBackgroundMusicUrl()).thenReturn("https://opengameart.org/sites/default/files/DST-TowerDefenseTheme_1.mp3");
+        when(mockGameContext.getMusicControl()).thenReturn(mockMusicControl);
+
+        gameMenuController.playBackgroundMusic(mockGameContext, mockGameSpec, mockMusicManager);
+
+        verify(mockMusicManager).backupPlaylist();
+    }
+
+    @Test
+    void shouldNotSetBackgroundMusic() {
+        when(mockMusicManager.getCurrentMusic().getMedia().getSource()).thenReturn("another-song.mp3");
+        when(mockMusicManager.getPlaylist().isEmpty()).thenReturn(false);
+
+        gameMenuController.playBackgroundMusic(mockGameContext, mockGameSpec, mockMusicManager);
+
+        assertTrue(BackgroundMusicManager.getInstance().getBackupPlaylist().isEmpty());
+    }
+
+}

--- a/gazeplay/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/gazeplay/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
This intends to fix #1011 

The initial idea is to check if the default music is playing, and use that as a basis for whether the user wants to hear their own music, or the music chosen by us for the game. I believe we should always favour the user's music.

Next steps are to make sure the default music is restarted when the game exits.