### PR TITLE
Updated Website with links to new version

### DIFF
--- a/docs/_includes/masthead.html
+++ b/docs/_includes/masthead.html
@@ -27,7 +27,7 @@
   function determineHomePage() {
     var current = document.URL;
     if (current.includes("fr")) {
-      return "/GazePlay/fr/";
+      return "/GazePlay/fr";
     } else {
       return "/GazePlay/";
     }

--- a/docs/_pages/installation.md
+++ b/docs/_pages/installation.md
@@ -5,7 +5,7 @@ layout: single
 ---
 
 ## Using the Windows Installer
-Download the installer and double click to open it. You will be guided through the installer, and you can then access GazePlay by the desktop icon or through the Start Menu.
+[Download the installer](https://github.com/GazePlay/GazePlay/releases/download/1.7.0/GazePlayInstaller.exe) and double click to open it. You will be guided through the installer, and you can then access GazePlay by the desktop icon or through the Start Menu.
 
 ## Advanced - Unpacking the .zip
 You can also install GazePlay by downloading [the zip file]({{ site.zip_url }}) and extracting the contents to a safe location on your computer. You can then launch GazePlay by running; 

--- a/docs/_pages/updates/latest_version1.7_eng.md
+++ b/docs/_pages/updates/latest_version1.7_eng.md
@@ -1,6 +1,6 @@
 ---
 title: Close this window to start GazePlay
-permalink: /updates/gazeplay-1-7-eng/
+permalink: /updates/gazeplay-1-7-0-eng/
 layout: single
 ---
 
@@ -18,5 +18,5 @@ It is possible to support the development of GazePlay through donations. These d
 
 ---
 
-GazePlay 1.7 – http://www.gazeplay.net – <gazeplay.net@gmail.com>  
+GazePlay 1.7.0 – <http://www.gazeplay.net> – <gazeplay.net@gmail.com>  
 GAZEPLAY Copyright (C) 2016-2020 Univ. Grenoble Alpes, CNRS, LIG UMR 5217

--- a/docs/_pages/updates/latest_version1.7_fra.md
+++ b/docs/_pages/updates/latest_version1.7_fra.md
@@ -1,6 +1,6 @@
 ---
 title: Fermez cette fenêtre pour démarrer GazePlay
-permalink: /updates/gazeplay-1-7-fra/
+permalink: /updates/gazeplay-1-7-0-fra/
 layout: single
 ---
 
@@ -17,5 +17,5 @@ Le sourire de vos enfants est notre meilleure récompense
 
 Il est possible de soutenir le développement de GazePlay par des dons. Ces dons serviront à financer le recrutement de stagiaires pour aider au développement du logiciel (env. 550€/mois) ou les frais annexes (location d’url, env. 13 euros/an/url, l’achat de matériel informatique comme les eye-trackers, site Web, …). <https://paypal.me/pools/c/80nEd8cVq5> ou contactez-nous par mail <gazeplay.net@gmail.com>
 
-GazePlay 1.7 – <http://gazeplay.net> – <gazeplay.net@gmail.com>
+GazePlay 1.7.0 – <http://gazeplay.net> – <gazeplay.net@gmail.com>
 GAZEPLAY Copyright (C) 2016-2020 Univ. Grenoble Alpes, CNRS, LIG UMR 5217

--- a/docs/_pages/updates/latest_version_eng.md
+++ b/docs/_pages/updates/latest_version_eng.md
@@ -1,6 +1,6 @@
 ---
 title: Close this window to start GazePlay
-permalink: /updates/gazeplay-${version}-eng/
+permalink: /updates/gazeplay-1-6-1-eng/
 layout: single
 ---
 
@@ -16,5 +16,5 @@ It is possible to support the development of GazePlay through donations. These d
 
 ---
 
-GazePlay ${version} – http://www.gazeplay.net – <gazeplay.net@gmail.com>  
+GazePlay 1.6.1 – http://www.gazeplay.net – <gazeplay.net@gmail.com>  
 GAZEPLAY Copyright (C) 2016-2020 Univ. Grenoble Alpes, CNRS, LIG UMR 5217

--- a/docs/fr/_pages/installation.md
+++ b/docs/fr/_pages/installation.md
@@ -5,7 +5,7 @@ layout: single
 ---
 
 ## Utilisation de Windows Installer
-Téléchargez le programme d'installation et double-cliquez pour l'ouvrir. Vous serez guidé à travers le programme d'installation, et vous pourrez ensuite accéder à GazePlay par l'icône du bureau ou via le menu Démarrer.
+[Téléchargez le programme d'installation](https://github.com/GazePlay/GazePlay/releases/download/1.7.0/GazePlayInstaller.exe) et double-cliquez pour l'ouvrir. Vous serez guidé à travers le programme d'installation, et vous pourrez ensuite accéder à GazePlay par l'icône du bureau ou via le menu Démarrer.
 
 ## Advanced - Déballage du .zip
 Vous pouvez également installer GazePlay en téléchargeant [le fichier zip]({{site.zip_url}}) et en extrayant le contenu vers un emplacement sûr sur votre ordinateur. Vous pouvez ensuite lancer GazePlay en exécutant;

--- a/docs/index-fr.md
+++ b/docs/index-fr.md
@@ -8,10 +8,10 @@ header:
   overlay_image: /assets/images/gazeplayClassicLogo.png
   actions:
     - label: "<i class='fas fa-download'></i> Installer maintenant"
-      url: https://github.com/GazePlay/GazePlay/releases/download/gazeplay-project-1.6.1/gazeplay-dist-1.6.1.zip
+      url: https://github.com/GazePlay/GazePlay/releases/download/1.7.0/GazePlayInstaller.exe
 excerpt: >
   GazePlay est un logiciel libre et gratuit qui rassemble plusieurs mini-jeux jouables grâce à un occulomètre (Eye-tracker).<br />
-  <small><a href="https://github.com/GazePlay/GazePlay/releases/tag/gazeplay-project-1.6.1">Dernière version v1.6.1</a></small>
+  <small><a href="https://github.com/GazePlay/GazePlay/releases/tag/1.7.0">Dernière version v1.7.0</a></small>
 ---
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/Ml8Plf3sVvk" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,10 +8,10 @@ header:
     overlay_image: /assets/images/gazeplayClassicLogo.png
     actions:
         - label: "<i class='fas fa-download'></i> Install now"
-          url: https://github.com/GazePlay/GazePlay/releases/download/gazeplay-project-1.6.1/gazeplay-dist-1.6.1.zip
+          url: https://github.com/GazePlay/GazePlay/releases/download/1.7.0/GazePlayInstaller.exe
 excerpt: >
   Gazeplay is free and open-source software, gathering nearly 60 mini-games playable with an eye-tracker.<br />
-  <small><a href="https://github.com/GazePlay/GazePlay/releases/tag/gazeplay-project-1.6.1">Latest release v1.6.1</a></small>
+  <small><a href="https://github.com/GazePlay/GazePlay/releases/tag/1.7.0">Latest release v1.7.0</a></small>
 ---
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/xGKCIiYNu2c" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>


### PR DESCRIPTION
Now that v1.7.0 is released, the links the app will point to are a bit off. This will fix them, and also make changes around the site to point to the new version.