### PR TITLE
InnoSetup Windows installer build on Linux

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -19,9 +19,9 @@ jobs:
       - name: Package with Gradle (no test)
         run: |
           ./gradlew --stacktrace --info packageApp -x test
-      - name: Remove files that should not be saved
-        run: |
-          find build/distributions/ -type f -not -name "gazeplay-project-*.zip" -delete
+      - name: Generate Windows Installer with InnoSetup
+        run:
+          ./gradlew --stacktrace --info generateInstaller
       - name: Save Package Job Artifacts
         uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,7 +20,8 @@ jobs:
         run: |
           ./gradlew --stacktrace --info packageApp -x test
       - name: Generate Windows Installer with InnoSetup
-        run:
+        run: |
+          chmod 777 build/distributions
           ./gradlew --stacktrace --info generateInstaller
       - name: Save Package Job Artifacts
         uses: actions/upload-artifact@v1

--- a/build.gradle
+++ b/build.gradle
@@ -135,9 +135,15 @@ distributions {
     }
 }
 
+distTar {
+    enabled = true
+    compression = Compression.GZIP
+    extension = 'tar.gz'
+}
 distZip {
     duplicatesStrategy = 'exclude'
 }
+[bootJar, bootDistTar, bootDistZip]*.enabled = false
 
 runtime {
     options = ['--compress', '2', '--no-header-files', '--no-man-pages']

--- a/gradle/innosetup/setup.iss.skel
+++ b/gradle/innosetup/setup.iss.skel
@@ -33,8 +33,9 @@ DefaultDirName={pf}\\GazePlay
 DefaultGroupName=GazePlay
 LicenseFile=licence.txt
 
-OutputBaseFilename=GazePlayInstaller
-Compression=lzma
+OutputDir=..\\distributions
+OutputBaseFilename=GazePlay-installer-${applicationVersion}
+;Compression=lzma
 SolidCompression=yes
 
 [Tasks]

--- a/gradle/installer.gradle
+++ b/gradle/installer.gradle
@@ -1,45 +1,52 @@
-task generateInstaller(dependsOn: ['unzipDistribution']) {
+task generateInstaller(dependsOn: ['unzipDistribution', 'prepareInnoSetupFiles']) {
     doLast {
+
         def innoSetupDir = new File("${buildDir}/innosetup")
-
-        innoSetupDir.mkdir()
-
-        copy {
-            from("${rootDir}/gradle/innosetup/setup.iss.skel")
-            rename("setup.iss.skel", "setup.iss")
-            expand([
-                    applicationVersion: "${version}",
-                    unpackedDirectory : "gazeplay-project-${version}"
-            ])
-            into(innoSetupDir)
-        }
-
-        copy {
-            from("${rootDir}/gazeplay/src/main/resources/data/common/licence.txt")
-            expand([
-                    "version": project.version,
-                    "date"   : new Date().format('yyyy-MM-dd')
-            ])
-            into(innoSetupDir)
-        }
-
-        copy {
-            from("${rootDir}/gradle/innosetup/gazeplayicon.ico")
-            into(innoSetupDir)
-        }
-
-        copy {
-            from("${rootDir}/gradle/innosetup/gazeplayicon.bmp")
-            into(innoSetupDir)
-        }
-
+        
         // I'm leaving this line in so we can quickly sign installers if/when we decide to do so.
         // def signtool = "/SStandard=\"C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.18362.0\\x64\\signtool.exe sign /a /n \$qGazePlay\$q /tr http://timestamp.comodoca.com/ /d \$qGazePlay\$q \$f\""
 
         exec {
             workingDir rootDir
-            commandLine "C:\\Program Files (x86)\\Inno Setup 6\\ISCC.exe", "${innoSetupDir}\\setup.iss"
+            //commandLine "C:\\Program Files (x86)\\Inno Setup 6\\ISCC.exe", "${innoSetupDir}\\setup.iss"
+            commandLine "docker", "run", "--rm", "-i", "-v", "${buildDir}:/work", "amake/innosetup", "innosetup/setup.iss"
         }
+    }
+}
+
+task prepareInnoSetupFiles(type: Copy) {
+
+    def innoSetupDir = new File("${buildDir}/innosetup")
+
+    innoSetupDir.mkdir()
+
+    copy {
+        from("${rootDir}/gradle/innosetup/setup.iss.skel")
+        rename("setup.iss.skel", "setup.iss")
+        expand([
+                applicationVersion: "${version}",
+                unpackedDirectory : "gazeplay-project-${version}"
+        ])
+        into(innoSetupDir)
+    }
+
+    copy {
+        from("${rootDir}/gazeplay/src/main/resources/data/common/licence.txt")
+        expand([
+                "version": project.version,
+                "date"   : new Date().format('yyyy-MM-dd')
+        ])
+        into(innoSetupDir)
+    }
+
+    copy {
+        from("${rootDir}/gradle/innosetup/gazeplayicon.ico")
+        into(innoSetupDir)
+    }
+
+    copy {
+        from("${rootDir}/gradle/innosetup/gazeplayicon.bmp")
+        into(innoSetupDir)
     }
 }
 


### PR DESCRIPTION
include build of the Windows installer distributable file in the CD pipeline. 
InnoSetup is executed in a linux docker container running wine.

also:
- windows distributable file name now contains version label, as other distributable files.
- disabled spring boot jar, zip, tar.
- all distributable files can be uploaded to S3