### PR TITLE
Console appender loggging Threshold

### DIFF
--- a/gazeplay-commons/src/main/resources/logback.xml
+++ b/gazeplay-commons/src/main/resources/logback.xml
@@ -5,7 +5,7 @@
             <pattern>%date{ISO8601} %-5level %logger - %msg%n</pattern>
         </encoder>
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>NONE</level>
+            <level>${logging.appender.console.level:-INFO}</level>
         </filter>
     </appender>
 
@@ -32,9 +32,9 @@
         <appender-ref ref="STDOUT"/>
     </appender>
 
-    <logger name="org.springframework" level="NONE"/>
+    <logger name="org.springframework" level="INFO"/>
 
-    <root level="NONE">
+    <root level="DEBUG">
         <appender-ref ref="ASYNC_FILE"/>
         <appender-ref ref="ASYNC_STDOUT"/>
     </root>

--- a/gazeplay-dist/src/main/bin/gazeplay-linux.sh
+++ b/gazeplay-dist/src/main/bin/gazeplay-linux.sh
@@ -5,6 +5,7 @@ set -e
 MAIN_JAR_FILE=gazeplay-@VERSION@.jar
 
 export JAVA_OPTS="-Xms256m -Xmx1g"
+export JAVA_OPTS="$JAVA_OPTS -Dlogging.appender.console.level=WARN"
 
 WORKING_DIR=$(pwd)
 
@@ -24,7 +25,7 @@ echo "LIB_DIR_RELATIVE = ${LIB_DIR_RELATIVE}"
 
 CLASSPATH=$(find ./$LIB_DIR_RELATIVE -name "*.jar" | sort | tr '\n' ':')
 
-export JAVA_CMD="java -cp \"$CLASSPATH\" ${JAVA_OPTS} net.gazeplay.GazePlayLauncher" 
+export JAVA_CMD="java -cp \"$CLASSPATH\" ${JAVA_OPTS} net.gazeplay.GazePlayLauncher"
 
 echo "Executing command line: $JAVA_CMD"
 

--- a/gazeplay-dist/src/main/bin/gazeplay-macos.sh
+++ b/gazeplay-dist/src/main/bin/gazeplay-macos.sh
@@ -3,6 +3,7 @@
 set -e
 
 export JAVA_OPTS="-Xms256m -Xmx1g"
+export JAVA_OPTS="$JAVA_OPTS -Dlogging.appender.console.level=WARN"
 
 CLASSPATH=$(find ../lib -name "*.jar" | sort | tr '\n' ':')
 

--- a/gazeplay-dist/src/main/bin/gazeplay-windows.bat
+++ b/gazeplay-dist/src/main/bin/gazeplay-windows.bat
@@ -3,6 +3,6 @@
 SET JAVA_HOME=..\lib\jre
 SET PATH=%JAVA_HOME%\bin;%PATH%;%LocalAppData%\TobiiStreamEngineForJava\lib\tobii\x64
 
-java -cp "..\lib\*" -Xms256m -Xmx1g net.gazeplay.GazePlayLauncher
+java -cp "..\lib\*" -Xms256m -Xmx1g -Dlogging.appender.console.level=WARN net.gazeplay.GazePlayLauncher
 
 pause


### PR DESCRIPTION
use WARN logging threshold for console appender when running for launcher scripts, to avoid logging many message to console for end users. By default, uses INFO level to have more log message for instance when running from the IDE