### PR TITLE
add pmd plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,9 +13,11 @@ plugins {
     id 'io.spring.dependency-management' version '1.0.8.RELEASE'
 }
 
-// Add -PSpotBugs=false to the Gradle Command Line to not run spotbugs.
-String value = project.getProperties().get('SpotBugs')
-boolean SpotBugs = Boolean.parseBoolean(value) ?: true
+// Add -PSpotBugs=false to the Gradle Command Line to not run spotbugs
+boolean spotbugsEnabled = Boolean.parseBoolean(project.getProperties().get('SpotBugs')) ?: true
+
+// Add -Ppmd=false to the Gradle Command Line to not run spotbugs
+boolean pmdEnabled = Boolean.parseBoolean(project.getProperties().get('pmd')) ?: true
 
 ext.javafxVersion = "11.0.2"
 
@@ -50,6 +52,7 @@ subprojects {
     apply plugin: 'io.freefair.lombok'
     apply plugin: 'com.github.hierynomus.license-report'
     apply plugin: 'com.github.spotbugs'
+    apply plugin: "pmd"
     apply plugin: 'distribution'
 
     sourceSets {
@@ -84,8 +87,8 @@ subprojects {
         excludeFilter = file("spotbugs-exclude.xml")
     }
 
-    spotbugsMain.enabled = SpotBugs
-    spotbugsTest.enabled = SpotBugs
+    spotbugsMain.enabled = spotbugsEnabled
+    spotbugsTest.enabled = spotbugsEnabled
 
     downloadLicenses {
         dependencyConfiguration = 'compileClasspath'
@@ -125,6 +128,19 @@ subprojects {
     }
 
     tasks.jacocoTestReport.dependsOn('test')
+
+    pmd {
+        ignoreFailures = true
+        rulePriority = 1
+        sourceSets = [sourceSets.main, sourceSets.test]
+        reportsDir = file("$project.buildDir/reports/pmd")
+        ruleSets = []
+        ruleSetFiles = files(rootProject.file("pmd-ruleset.xml"))
+    }
+    
+    pmdMain.enabled = pmdEnabled
+    pmdTest.enabled = pmdEnabled
+
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
 // Add -PSpotBugs=false to the Gradle Command Line to not run spotbugs
 boolean spotbugsEnabled = Boolean.parseBoolean(project.getProperties().get('SpotBugs')) ?: true
 
-// Add -Ppmd=false to the Gradle Command Line to not run spotbugs
+// Add -Ppmd=false to the Gradle Command Line to not run PMD
 boolean pmdEnabled = Boolean.parseBoolean(project.getProperties().get('pmd')) ?: true
 
 ext.javafxVersion = "11.0.2"

--- a/pmd-ruleset.xml
+++ b/pmd-ruleset.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<ruleset name="Custom Rules"
+         xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
+
+    <description>Ruleset for PMD for our particular project</description>
+
+    <exclude-pattern>.*/gazeplay-side-projects/.*</exclude-pattern>
+    <exclude-pattern>.*/gazeplay-picto-pick/.*</exclude-pattern>
+    <exclude-pattern>.*/gazeplay-melordi/.*</exclude-pattern>
+
+    <rule ref="category/java/errorprone.xml">
+        <exclude name="BeanMembersShouldSerialize"/>
+        <exclude name="ConstructorCallsOverridableMethod"/>
+    </rule>
+
+    <rule ref="category/java/bestpractices.xml">
+        <exclude name="GuardLogStatement"/>
+    </rule>
+    
+    <rule ref="category/java/codestyle.xml">
+        <exclude name="FieldNamingConventions"/>
+    </rule>
+
+    <rule ref="category/java/design.xml">
+    </rule>
+    
+    <rule ref="category/java/multithreading.xml">
+    </rule>
+    
+    <rule ref="category/java/performance.xml">
+    </rule>
+
+</ruleset>


### PR DESCRIPTION
pmd plugin performs static analysis on code base.

it helps enforcing coding conventions.

for the moment, the plugin is enabled by default but does not fail the build when a violation is found,
because there are a lot of existing violations in the current code base.

so the idea is to iteratively fix all existing violations
and when it's done, make the plugin fail the build so that no new violation comes in. 

You can run pmd analysis by running
```
./gradlew pmdMain
```

You can see violation in browser by running
```
find . -name "*.html" | grep pmd | xargs firefox
```
