### PR TITLE
PMD Problems - FilesUtilities

### DIFF
--- a/gazeplay/src/main/java/net/gazeplay/commons/utils/FileUtils.java
+++ b/gazeplay/src/main/java/net/gazeplay/commons/utils/FileUtils.java
@@ -5,13 +5,13 @@ import lombok.extern.slf4j.Slf4j;
 import java.io.File;
 
 @Slf4j
-public class FilesUtility {
+public class FileUtils {
 
-    public static void deleteDirectoryRecursivly(File file) {
+    public static void deleteDirectoryRecursively(File file) {
         File[] contents = file.listFiles();
         if (contents != null) {
             for (File f : contents) {
-                deleteDirectoryRecursivly(f);
+                deleteDirectoryRecursively(f);
             }
         }
         boolean deleted = file.delete();

--- a/gazeplay/src/main/java/net/gazeplay/ui/scenes/userselect/UserProfilContext.java
+++ b/gazeplay/src/main/java/net/gazeplay/ui/scenes/userselect/UserProfilContext.java
@@ -34,12 +34,11 @@ import net.gazeplay.commons.configuration.Configuration;
 import net.gazeplay.commons.configuration.ConfigurationSource;
 import net.gazeplay.commons.utils.ControlPanelConfigurator;
 import net.gazeplay.commons.utils.CustomButton;
-import net.gazeplay.commons.utils.FilesUtility;
+import net.gazeplay.commons.utils.FileUtils;
 import net.gazeplay.commons.utils.games.BackgroundMusicManager;
 import net.gazeplay.commons.utils.games.GazePlayDirectories;
 import net.gazeplay.components.CssUtil;
 import net.gazeplay.ui.GraphicalContext;
-import org.apache.commons.io.FileUtils;
 
 import java.io.*;
 import java.util.ArrayList;
@@ -321,7 +320,7 @@ public class UserProfilContext extends GraphicalContext<BorderPane> {
             dialog.close();
             choicePanel.getChildren().remove(user);
             File userDirectory = GazePlayDirectories.getUserProfileDirectory(user.getName());
-            FilesUtility.deleteDirectoryRecursivly(userDirectory);
+            FileUtils.deleteDirectoryRecursively(userDirectory);
             log.info("Profile: " + user.getName() + " deleted");
         });
 
@@ -563,7 +562,7 @@ public class UserProfilContext extends GraphicalContext<BorderPane> {
 
     private static boolean copyFile(File source, File dest) {
         try {
-            FileUtils.copyFile(source, dest);
+            org.apache.commons.io.FileUtils.copyFile(source, dest);
             return true;
         } catch (Exception e) {
             log.info("Unable to copy the profile picture");

--- a/gazeplay/src/test/java/net/gazeplay/commons/utils/FileUtilsTest.java
+++ b/gazeplay/src/test/java/net/gazeplay/commons/utils/FileUtilsTest.java
@@ -1,0 +1,65 @@
+package net.gazeplay.commons.utils;
+
+
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class FileUtilsTest {
+
+    @Test
+    void shouldDeleteShallowDirectory() throws IOException {
+        File parent = new File("parent");
+        parent.mkdir();
+        File test = new File("parent/test.txt");
+        test.createNewFile();
+
+        assertTrue(parent.isDirectory());
+        assertTrue(test.isFile());
+
+        FileUtils.deleteDirectoryRecursively(parent);
+
+        assertFalse(parent.isDirectory());
+        assertFalse(test.isFile());
+    }
+
+    @Test
+    void shouldDeleteSingleFile() throws IOException {
+        File test = new File("test.txt");
+        test.createNewFile();
+
+        assertTrue(test.isFile());
+
+        FileUtils.deleteDirectoryRecursively(test);
+
+        assertFalse(test.isFile());
+    }
+
+    @Test
+    void shouldDeleteDeepDirectory() throws IOException {
+        File parent = new File("parent/child/deep");
+        parent.mkdirs();
+        File test = new File("parent/child/deep/test.txt");
+        test.createNewFile();
+        File test2 = new File("parent/child/test2.txt");
+        test2.createNewFile();
+        File test3 = new File("parent/test3.txt");
+        test3.createNewFile();
+
+        assertTrue(parent.isDirectory());
+        assertTrue(test.isFile());
+        assertTrue(test2.isFile());
+        assertTrue(test3.isFile());
+
+        FileUtils.deleteDirectoryRecursively(new File("parent"));
+
+        assertFalse(parent.isDirectory());
+        assertFalse(test.isFile());
+        assertFalse(test2.isFile());
+        assertFalse(test3.isFile());
+    }
+}


### PR DESCRIPTION
### PMD Problems
`FilesUtilities` - [ClassNamingConventions](https://pmd.github.io/pmd-6.17.0/pmd_rules_java_codestyle.html#classnamingconventions)

### Solution
Simply changing the class name is enough to get this to match naming conventions.

### Extras
Added full test coverage