### PR TITLE
Promote 'Silver and Gold' as default theme for UI

### DIFF
--- a/gazeplay-commons/src/main/java/net/gazeplay/commons/themes/BuiltInUiTheme.java
+++ b/gazeplay-commons/src/main/java/net/gazeplay/commons/themes/BuiltInUiTheme.java
@@ -54,7 +54,7 @@ public enum BuiltInUiTheme {
         return PRE_BUILD_STYLESHEETS_LOCATION + stylesheetResourceName;
     }
 
-    public static final BuiltInUiTheme DEFAULT_THEME = GREEN;
+    public static final BuiltInUiTheme DEFAULT_THEME = SILVER_AND_GOLD;
 
     public static Optional<BuiltInUiTheme> findFromConfigPropertyValue(String configPropertyValue) {
         for (BuiltInUiTheme builtInUiTheme : BuiltInUiTheme.values()) {


### PR DESCRIPTION
, in replacement of the 'Green' theme. The 'Silver and Gold' theme is considered more classic than the 'Green' one, thus should fit more people