### PR TITLE
Solving #1074 - Uninstall GazePlay if already installed

### DIFF
--- a/gradle/innosetup/setup.iss.skel
+++ b/gradle/innosetup/setup.iss.skel
@@ -55,3 +55,45 @@ Name: "{commondesktop}\\GazePlay"; Filename: "{app}\\bin\\gazeplay-windows.bat";
 
 [Run]
 Filename: "{app}\\bin\\gazeplay-windows.bat"; Description: "{cm:LaunchProgram,GazePlay}"; Flags: shellexec postinstall skipifsilent
+
+[Code]
+function GetUninstallString: string;
+var
+  sUnInstPath: string;
+  sUnInstallString: String;
+begin
+  Result := '';
+  sUnInstPath := ExpandConstant('Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\GazePlay_is1'); { Your App GUID/ID }
+  sUnInstallString := '';
+  if not RegQueryStringValue(HKLM, sUnInstPath, 'UninstallString', sUnInstallString) then
+    RegQueryStringValue(HKCU, sUnInstPath, 'UninstallString', sUnInstallString);
+  Result := sUnInstallString;
+end;
+
+function IsUpgrade: Boolean;
+begin
+  Result := (GetUninstallString() <> '');
+end;
+
+function InitializeSetup: Boolean;
+var
+  V: Integer;
+  iResultCode: Integer;
+  sUnInstallString: string;
+begin
+  Result := True; { in case when no previous version is found }
+  if RegValueExists(HKEY_LOCAL_MACHINE,'Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\GazePlay_is1', 'UninstallString') then  { Your App GUID/ID }
+  begin
+    V := MsgBox(ExpandConstant('An older version of GazePlay was detected. Do you want to uninstall it?'), mbInformation, MB_YESNO); { Custom Message if App installed }
+    if V = IDYES then
+    begin
+      sUnInstallString := GetUninstallString();
+      sUnInstallString :=  RemoveQuotes(sUnInstallString);
+      Exec(ExpandConstant(sUnInstallString), '', '', SW_SHOW, ewWaitUntilTerminated, iResultCode);
+      Result := True; { if you want to proceed after uninstall }
+      { Exit; //if you want to quit after uninstall }
+    end
+    else
+      Result := False; { when older version present and not uninstalled }
+  end;
+end;


### PR DESCRIPTION
Solves #1074 

Gets the Uninstaller and offers to run it if it detects the App already installed.