### PR TITLE
check PMD to prevent introduction of more violations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           java-version: 11
       - name: Build with Gradle (no test)
-        run: ./gradlew --stacktrace --info build -x test
+        run: ./gradlew --stacktrace --info build checkPMDReport -x test
       - name: Set up xvfb for non headless tests
         run: sudo apt-get install xvfb
       - name: Run tests with Gradle

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,4 +25,4 @@ before_install:
 install: true
 
 script:
-  - ./gradlew -PexcludeTests=**/*Music*
+  - ./gradlew build checkPMDReport -PexcludeTests=**/*Music*

--- a/build.gradle
+++ b/build.gradle
@@ -131,15 +131,52 @@ subprojects {
 
     pmd {
         ignoreFailures = true
-        rulePriority = 1
+        rulePriority = 2
         sourceSets = [sourceSets.main, sourceSets.test]
         reportsDir = file("$project.buildDir/reports/pmd")
         ruleSets = []
         ruleSetFiles = files(rootProject.file("pmd-ruleset.xml"))
     }
-    
+
     pmdMain.enabled = pmdEnabled
     pmdTest.enabled = pmdEnabled
+
+    task checkPMDReport {
+        doLast {
+            def pmdReportDir = file("$project.buildDir/reports/pmd/")
+            if (pmdReportDir.exists()) {
+                def pmdReportXml = file("$project.buildDir/reports/pmd/main.xml")
+                if (pmdReportXml.exists()) {
+                    def pmdReportHtml = file("$project.buildDir/reports/pmd/main.html")
+                    def rootNode = new XmlSlurper().parse("$pmdReportXml")
+                    // thresholds are set from actual observations of the number of violation
+                    // goal is that no new violations come in the code base
+                    // as we progressively fix existing violations (or exclude them in pmd-ruleset.xml), we should lower the threshold accordingly
+                    // until the threshold is zero
+                    def violationsThresholds = [
+                            1: 42,
+                            2: 9,
+                            3: 7572,
+                            4: 208,
+                            5: 437
+                    ]
+                    violationsThresholds.each {
+                        priorityLevel, violationsThreshold ->
+
+                            def violationsCount = rootNode.children().children().findAll({ node -> node.name() == 'violation' && node.@priority == priorityLevel }).size()
+                            def violationsMessage = "$violationsCount PMD rule 'priority $priorityLevel' violations were found. See the report at: file://$pmdReportHtml";
+                            if (violationsCount > violationsThreshold) {
+                                throw new GradleException(violationsMessage)
+                            } else {
+                                if (violationsCount > 0) {
+                                    println violationsMessage
+                                }
+                            }
+                    };
+                }
+            }
+        }
+    }
 
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -234,7 +234,7 @@ release {
 
 mainClassName = 'net.gazeplay.GazePlayLauncher'
 
-defaultTasks 'clean', 'build'
+defaultTasks 'clean', 'build', 'checkPMDReport'
 startScripts.enabled = false
 
 afterReleaseBuild.dependsOn generateInstaller


### PR DESCRIPTION
introduced a check task that checks PMD reports, and fails if the number of violation for any priority level is over a predefinied limit. This allows to acknowledge existing number of violations while preventing introduction of new violations