### PR TITLE
Fix for time problem in stats

### DIFF
--- a/gazeplay/src/main/java/net/gazeplay/commons/utils/stats/StatDisplayUtils.java
+++ b/gazeplay/src/main/java/net/gazeplay/commons/utils/stats/StatDisplayUtils.java
@@ -348,7 +348,13 @@ public class StatDisplayUtils {
         long days = duration.toDaysPart();
         Duration durationLessDays = duration.minusDays(days);
 
-        return String.format("%dd ", days) + durationLessDays.toString()
+        String result = "";
+
+        if (days > 0) {
+            result += String.format("%dd ", days);
+        }
+
+        return result + durationLessDays.toString()
             .substring(2)
             .replaceAll("(\\d[HMS])(?!$)", "$1 ")
             .toLowerCase();

--- a/gazeplay/src/main/java/net/gazeplay/commons/utils/stats/StatDisplayUtils.java
+++ b/gazeplay/src/main/java/net/gazeplay/commons/utils/stats/StatDisplayUtils.java
@@ -28,6 +28,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static javafx.scene.chart.XYChart.Data;
 
@@ -340,9 +341,11 @@ public class StatDisplayUtils {
     }
 
     public static String convert(long totalTime) {
-        Date date = new Date(totalTime);
-        DateFormat df = new SimpleDateFormat("dd 'd' HH 'h' mm 'm' ss 's' S 'ms'");
-
-        return df.format(date);
+        return String.format("%02d d %02d h %02d m %02d s %04d ms",
+            TimeUnit.MILLISECONDS.toDays(totalTime),
+            TimeUnit.MILLISECONDS.toHours(totalTime) % TimeUnit.DAYS.toHours(1),
+            TimeUnit.MILLISECONDS.toMinutes(totalTime) % TimeUnit.HOURS.toMinutes(1),
+            TimeUnit.MILLISECONDS.toSeconds(totalTime) % TimeUnit.MINUTES.toSeconds(1),
+            TimeUnit.MILLISECONDS.toMillis(totalTime) % TimeUnit.SECONDS.toMillis(1));
     }
 }

--- a/gazeplay/src/main/java/net/gazeplay/commons/utils/stats/StatDisplayUtils.java
+++ b/gazeplay/src/main/java/net/gazeplay/commons/utils/stats/StatDisplayUtils.java
@@ -341,11 +341,19 @@ public class StatDisplayUtils {
     }
 
     public static String convert(long totalTime) {
-        return String.format("%02d d %02d h %02d m %02d s %04d ms",
-            TimeUnit.MILLISECONDS.toDays(totalTime),
-            TimeUnit.MILLISECONDS.toHours(totalTime) % TimeUnit.DAYS.toHours(1),
-            TimeUnit.MILLISECONDS.toMinutes(totalTime) % TimeUnit.HOURS.toMinutes(1),
-            TimeUnit.MILLISECONDS.toSeconds(totalTime) % TimeUnit.MINUTES.toSeconds(1),
-            TimeUnit.MILLISECONDS.toMillis(totalTime) % TimeUnit.SECONDS.toMillis(1));
+        long days = TimeUnit.MILLISECONDS.toDays(totalTime);
+        long hours = TimeUnit.MILLISECONDS.toHours(totalTime) % TimeUnit.DAYS.toHours(1);
+        long minutes = TimeUnit.MILLISECONDS.toMinutes(totalTime) % TimeUnit.HOURS.toMinutes(1);
+        long seconds = TimeUnit.MILLISECONDS.toSeconds(totalTime) % TimeUnit.MINUTES.toSeconds(1);
+        long millis = TimeUnit.MILLISECONDS.toMillis(totalTime) % TimeUnit.SECONDS.toMillis(1);
+
+        StringBuilder builder = new StringBuilder();
+        if (days > 0) builder.append(String.format("%d d ", days));
+        if (hours > 0) builder.append(String.format("%02d h ", hours));
+        if (minutes > 0) builder.append(String.format("%02d m ", minutes));
+        if (seconds > 0) builder.append(String.format("%02d s ", seconds));
+        builder.append(String.format("%04d ms", millis));
+
+        return builder.toString();
     }
 }

--- a/gazeplay/src/main/java/net/gazeplay/commons/utils/stats/StatDisplayUtils.java
+++ b/gazeplay/src/main/java/net/gazeplay/commons/utils/stats/StatDisplayUtils.java
@@ -25,6 +25,7 @@ import net.gazeplay.ui.scenes.stats.StatsContext;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.time.Duration;
 import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
@@ -341,19 +342,15 @@ public class StatDisplayUtils {
     }
 
     public static String convert(long totalTime) {
-        long days = TimeUnit.MILLISECONDS.toDays(totalTime);
-        long hours = TimeUnit.MILLISECONDS.toHours(totalTime) % TimeUnit.DAYS.toHours(1);
-        long minutes = TimeUnit.MILLISECONDS.toMinutes(totalTime) % TimeUnit.HOURS.toMinutes(1);
-        long seconds = TimeUnit.MILLISECONDS.toSeconds(totalTime) % TimeUnit.MINUTES.toSeconds(1);
-        long millis = TimeUnit.MILLISECONDS.toMillis(totalTime) % TimeUnit.SECONDS.toMillis(1);
+        Duration duration = Duration.ofMillis(totalTime);
 
-        StringBuilder builder = new StringBuilder();
-        if (days > 0) builder.append(String.format("%d d ", days));
-        if (hours > 0) builder.append(String.format("%02d h ", hours));
-        if (minutes > 0) builder.append(String.format("%02d m ", minutes));
-        if (seconds > 0) builder.append(String.format("%02d s ", seconds));
-        builder.append(String.format("%04d ms", millis));
+        // Extract the days from the duration, then take it away so we can format the rest of the string.
+        long days = duration.toDaysPart();
+        Duration durationLessDays = duration.minusDays(days);
 
-        return builder.toString();
+        return String.format("%dd ", days) + durationLessDays.toString()
+            .substring(2)
+            .replaceAll("(\\d[HMS])(?!$)", "$1 ")
+            .toLowerCase();
     }
 }

--- a/gazeplay/src/test/java/net/gazeplay/commons/utils/stats/StatDisplayUtilsTest.java
+++ b/gazeplay/src/test/java/net/gazeplay/commons/utils/stats/StatDisplayUtilsTest.java
@@ -294,13 +294,13 @@ class StatDisplayUtilsTest {
         cal.set(2020, Calendar.JANUARY, 28, 14, 25, 25);
         long end = cal.getTimeInMillis();
         String result = StatDisplayUtils.convert(end - start);
-        assertTrue(result.contains("01 h 05 s"));
+        assertTrue(result.contains("1h 5s"));
 
         cal.set(2020, Calendar.JANUARY, 28, 13, 25, 20);
         start = cal.getTimeInMillis();
         cal.set(2020, Calendar.JANUARY, 29, 14, 26, 25);
         end = cal.getTimeInMillis();
         result = StatDisplayUtils.convert(end - start);
-        assertTrue(result.contains("1 d 01 h 01 m 05 s"));
+        assertTrue(result.contains("1d 1h 1m 5s"));
     }
 }

--- a/gazeplay/src/test/java/net/gazeplay/commons/utils/stats/StatDisplayUtilsTest.java
+++ b/gazeplay/src/test/java/net/gazeplay/commons/utils/stats/StatDisplayUtilsTest.java
@@ -289,10 +289,13 @@ class StatDisplayUtilsTest {
     void shouldConvertTimeToString() {
         final Calendar cal = Calendar.getInstance();
         cal.set(2020, Calendar.JANUARY, 28, 13, 25, 20);
-        final long input = cal.getTimeInMillis();
+        final long start = cal.getTimeInMillis();
 
-        final String result = StatDisplayUtils.convert(input);
+        cal.set(2020, Calendar.JANUARY, 28, 14, 25, 25);
+        final long end = cal.getTimeInMillis();
 
-        assertTrue(result.contains("28 d 13 h 25 m 20 s"));
+        final String result = StatDisplayUtils.convert(end - start);
+
+        assertTrue(result.contains("00 d 01 h 00 m 05 s"));
     }
 }

--- a/gazeplay/src/test/java/net/gazeplay/commons/utils/stats/StatDisplayUtilsTest.java
+++ b/gazeplay/src/test/java/net/gazeplay/commons/utils/stats/StatDisplayUtilsTest.java
@@ -288,14 +288,19 @@ class StatDisplayUtilsTest {
     @Test
     void shouldConvertTimeToString() {
         final Calendar cal = Calendar.getInstance();
+
         cal.set(2020, Calendar.JANUARY, 28, 13, 25, 20);
-        final long start = cal.getTimeInMillis();
-
+        long start = cal.getTimeInMillis();
         cal.set(2020, Calendar.JANUARY, 28, 14, 25, 25);
-        final long end = cal.getTimeInMillis();
+        long end = cal.getTimeInMillis();
+        String result = StatDisplayUtils.convert(end - start);
+        assertTrue(result.contains("01 h 05 s"));
 
-        final String result = StatDisplayUtils.convert(end - start);
-
-        assertTrue(result.contains("00 d 01 h 00 m 05 s"));
+        cal.set(2020, Calendar.JANUARY, 28, 13, 25, 20);
+        start = cal.getTimeInMillis();
+        cal.set(2020, Calendar.JANUARY, 29, 14, 26, 25);
+        end = cal.getTimeInMillis();
+        result = StatDisplayUtils.convert(end - start);
+        assertTrue(result.contains("1 d 01 h 01 m 05 s"));
     }
 }


### PR DESCRIPTION
Fixes issue #1084

## Problem
Turns out using `Date` for time differences so low makes it think its 01/01/1970 01:00:00, adding an extra 1 day and 1 hour to the difference.

## Solution
Instead doing some maths with the `TimeUnit` and formatting it in the desired manner makes it work correctly.

![image](https://user-images.githubusercontent.com/33665681/74054974-fde9ac00-49d6-11ea-8797-9e4ba2a1e8c5.png)
