### PR TITLE
Some more testing goodness

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -11,7 +11,7 @@ jobs:
   package:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,4 +18,4 @@ jobs:
       - name: Set up xvfb for non headless tests
         run: sudo apt-get install xvfb
       - name: Run tests with Gradle
-        run: xvfb-run --auto-servernum ./gradlew --stacktrace --info test -PexcludeTests=**/*Music*
+        run: xvfb-run --auto-servernum ./gradlew --stacktrace --info test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,4 +25,4 @@ before_install:
 install: true
 
 script:
-  - ./gradlew build checkPMDReport -PexcludeTests=**/*Music*
+  - ./gradlew build checkPMDReport

--- a/build.gradle
+++ b/build.gradle
@@ -56,15 +56,23 @@ subprojects {
     apply plugin: 'com.github.spotbugs'
     apply plugin: "pmd"
     apply plugin: 'distribution'
+    apply plugin: 'idea'
 
     sourceSets {
         integrationTest {
             java {
                 compileClasspath += main.output + test.output
                 runtimeClasspath += main.output + test.output
-                srcDir file('src/integration-test/java')
+                srcDir file('src/integrationTest/java')
             }
-            resources.srcDir file('src/integration-test/resources')
+            resources.srcDir file('src/integrationTest/resources')
+        }
+    }
+
+    idea {
+        module {
+            sourceDirs -= file('src/integrationTest/java')
+            testSourceDirs += file('src/integrationTest/java')
         }
     }
 
@@ -105,6 +113,7 @@ subprojects {
         testImplementation "org.testfx:openjfx-monocle:jdk-11+26"
         testImplementation "org.jmockit:jmockit:1.49"
         testImplementation "org.mockito:mockito-core:2.+"
+        testImplementation "org.springframework.boot:spring-boot-starter-test:2.2.1.RELEASE"
     }
 
     sourceCompatibility = '11'
@@ -126,6 +135,14 @@ subprojects {
         if (project.hasProperty('excludeTests')) {
             exclude project.property('excludeTests')
         }
+    }
+
+    // Add -Pheadless=false to the Gradle Command Line to see tests running. You WILL lose control of your
+    // mouse and keyboard during tests if this is false.
+    def headless = Boolean.parseBoolean(project.getProperties().get("headless")) ?: true
+
+    integrationTest {
+        jvmArgs = [ "-Dheadless=${headless}" ]
     }
 
     tasks.withType(Test) {

--- a/build.gradle
+++ b/build.gradle
@@ -113,7 +113,6 @@ subprojects {
         testImplementation "org.testfx:openjfx-monocle:jdk-11+26"
         testImplementation "org.jmockit:jmockit:1.49"
         testImplementation "org.mockito:mockito-core:2.+"
-        testImplementation "org.springframework.boot:spring-boot-starter-test:2.2.1.RELEASE"
     }
 
     sourceCompatibility = '11'

--- a/gazeplay-commons/src/main/java/net/gazeplay/commons/utils/games/BackgroundMusicManager.java
+++ b/gazeplay-commons/src/main/java/net/gazeplay/commons/utils/games/BackgroundMusicManager.java
@@ -384,10 +384,14 @@ public class BackgroundMusicManager {
         return outputFile;
     }
 
+    MediaPlayer makeMediaPlayer(Media media) {
+        return new MediaPlayer(media);
+    }
+
     MediaPlayer createMediaPlayer(String source) {
         try {
             final Media media = new Media(source);
-            final MediaPlayer player = new MediaPlayer(media);
+            final MediaPlayer player = makeMediaPlayer(media);
             player.setOnError(() -> log.error("error on audio media loading : " + player.getError()));
             player.volumeProperty().bindBidirectional(ActiveConfigurationContext.getInstance().getMusicVolumeProperty());
             player.setOnEndOfMedia(this::next);

--- a/gazeplay-commons/src/test/java/net/gazeplay/commons/utils/games/BackgroundMusicManagerTest.java
+++ b/gazeplay-commons/src/test/java/net/gazeplay/commons/utils/games/BackgroundMusicManagerTest.java
@@ -98,7 +98,7 @@ class BackgroundMusicManagerTest {
     @Test
     void shouldHaveTheSameVolumeAsVolumeProperty() {
         final double actualVolume = ActiveConfigurationContext.getInstance().getMusicVolumeProperty().getValue();
-        final double currentVolume = mediaPlayer.getVolume();
+        final double currentVolume = volumeProperty.get();
         assertEquals(currentVolume, actualVolume);
     }
 

--- a/gazeplay-commons/src/test/java/net/gazeplay/commons/utils/games/BackgroundMusicManagerTest.java
+++ b/gazeplay-commons/src/test/java/net/gazeplay/commons/utils/games/BackgroundMusicManagerTest.java
@@ -1,23 +1,43 @@
 package net.gazeplay.commons.utils.games;
 
+import javafx.beans.property.SimpleDoubleProperty;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableMap;
+import javafx.scene.media.Media;
 import javafx.scene.media.MediaPlayer;
 import net.gazeplay.commons.configuration.ActiveConfigurationContext;
+import org.junit.BeforeClass;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.testfx.framework.junit5.ApplicationExtension;
 
 import java.io.File;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
 
+@RunWith(MockitoJUnitRunner.class)
 @ExtendWith(ApplicationExtension.class)
 class BackgroundMusicManagerTest {
 
-    private final BackgroundMusicManager musicManager = BackgroundMusicManager.getInstance();
+    @Mock
+    MediaPlayer mockMediaPlayer;
+
+    @Mock
+    Media mockMedia;
+
+    private BackgroundMusicManager musicManagerSpy;
     private final String sep = File.separator;
     private final String localDataFolder =
         System.getProperty("user.dir") + sep
@@ -30,94 +50,112 @@ class BackgroundMusicManagerTest {
     private MediaPlayer mediaPlayer;
     private double previousVolume;
 
+    private SimpleDoubleProperty volumeProperty = new SimpleDoubleProperty(0.5);
+    ObservableMap<String, Object> metadata = FXCollections.observableHashMap();
+
     @BeforeEach
     void setup() {
+        initMocks();
         final String uri = new File(localDataFolder + "song.mp3").toURI().toString();
-        musicManager.getAudioFromFolder(localDataFolder);
-        mediaPlayer = musicManager.createMediaPlayer(uri);
-        previousVolume = musicManager.getCurrentMusic().getVolume();
+
+        musicManagerSpy.getAudioFromFolder(localDataFolder);
+        mediaPlayer = musicManagerSpy.createMediaPlayer(uri);
+        previousVolume = musicManagerSpy.getCurrentMusic().getVolume();
+    }
+
+    void initMocks() {
+        MockitoAnnotations.initMocks(this);
+
+        musicManagerSpy = spy(new BackgroundMusicManager());
+
+        doReturn(mockMediaPlayer).when(musicManagerSpy).makeMediaPlayer(any());
+        when(mockMediaPlayer.volumeProperty()).thenReturn(volumeProperty);
+
+        metadata.put("title", "Title");
+        when(mockMedia.getMetadata()).thenReturn(metadata);
+        when(mockMediaPlayer.getMedia()).thenReturn(mockMedia);
     }
 
     @AfterEach
     void teardown() {
-        if (musicManager.getCurrentMusic() != null) {
-            musicManager.getCurrentMusic().setVolume(previousVolume);
+        if (musicManagerSpy.getCurrentMusic() != null) {
+            musicManagerSpy.getCurrentMusic().setVolume(previousVolume);
         }
     }
 
     @Test
     void shouldCreateMediaPlayer() {
-        assert mediaPlayer != null;
+        assertNotNull(mediaPlayer);
     }
 
     @Test
     void shouldReturnNullOnError() {
         final String uri = new File(localDataFolder + "test.properties").toURI().toString();
-        mediaPlayer = musicManager.createMediaPlayer(uri);
-        assert mediaPlayer == null;
+        mediaPlayer = musicManagerSpy.createMediaPlayer(uri);
+        assertNull(mediaPlayer);
     }
 
     @Test
     void shouldHaveTheSameVolumeAsVolumeProperty() {
         final double actualVolume = ActiveConfigurationContext.getInstance().getMusicVolumeProperty().getValue();
         final double currentVolume = mediaPlayer.getVolume();
-        assert currentVolume == actualVolume;
+        assertEquals(currentVolume, actualVolume);
     }
 
     @ParameterizedTest
     @ValueSource(doubles = {0, 0.1, 0.5, 1})
     void shouldSetTheVolume(final double volume) {
-        musicManager.setVolume(volume);
-        assert musicManager.getCurrentMusic().getVolume() == volume;
+        musicManagerSpy.setVolume(volume);
+        verify(mockMediaPlayer).setVolume(volume);
     }
 
     @ParameterizedTest
     @ValueSource(doubles = {-0.1, 100, 1.1})
     void shouldNotSetTheVolume(final double volume) {
-        assertThrows(IllegalArgumentException.class, () -> musicManager.setVolume(volume));
+        assertThrows(IllegalArgumentException.class, () -> musicManagerSpy.setVolume(volume));
     }
 
     @Test
     void shouldBackupAndRestorePlaylist() {
-        final int numberOfTracks = musicManager.getPlaylist().size();
-        musicManager.backupPlaylist();
-        musicManager.emptyPlaylist();
-        musicManager.restorePlaylist();
-        assertEquals(numberOfTracks, musicManager.getPlaylist().size());
+        final int numberOfTracks = musicManagerSpy.getPlaylist().size();
+        musicManagerSpy.backupPlaylist();
+        musicManagerSpy.emptyPlaylist();
+        musicManagerSpy.restorePlaylist();
+        assertEquals(numberOfTracks, musicManagerSpy.getPlaylist().size());
     }
 
     @Test
     void shouldNotBackupOrRestoreEmptyPlaylist() {
-        final int numberOfTracks = musicManager.getPlaylist().size();
-        musicManager.emptyPlaylist();
+        final int numberOfTracks = musicManagerSpy.getPlaylist().size();
+        musicManagerSpy.emptyPlaylist();
 
-        musicManager.backupPlaylist();
-        musicManager.restorePlaylist();
+        musicManagerSpy.backupPlaylist();
+        musicManagerSpy.restorePlaylist();
 
-        assertNotEquals(numberOfTracks, musicManager.getPlaylist().size());
+        assertNotEquals(numberOfTracks, musicManagerSpy.getPlaylist().size());
     }
 
     @Test
     void shouldOnlyBackupThePlaylistOnce() {
-        final int numberOfTracks = musicManager.getPlaylist().size();
-        musicManager.backupPlaylist();
-        musicManager.backupPlaylist();
+        final int numberOfTracks = musicManagerSpy.getPlaylist().size();
+        musicManagerSpy.backupPlaylist();
+        musicManagerSpy.backupPlaylist();
 
-        musicManager.emptyPlaylist();
+        musicManagerSpy.emptyPlaylist();
 
-        musicManager.restorePlaylist();
-        assertEquals(numberOfTracks, musicManager.getPlaylist().size());
+        musicManagerSpy.restorePlaylist();
+        assertEquals(numberOfTracks, musicManagerSpy.getPlaylist().size());
     }
 
     @Test
     void shouldOnlyRestoreThePlaylistOnce() {
-        final int numberOfTracks = musicManager.getPlaylist().size();
-        musicManager.backupPlaylist();
+        final int numberOfTracks = musicManagerSpy.getPlaylist().size();
+        musicManagerSpy.backupPlaylist();
 
-        musicManager.emptyPlaylist();
+        musicManagerSpy.emptyPlaylist();
 
-        musicManager.restorePlaylist();
-        musicManager.restorePlaylist();
-        assertEquals(numberOfTracks, musicManager.getPlaylist().size());
+        musicManagerSpy.restorePlaylist();
+        musicManagerSpy.restorePlaylist();
+        assertEquals(numberOfTracks, musicManagerSpy.getPlaylist().size());
     }
 }

--- a/gazeplay/src/integrationTest/java/net/gazeplay/IntegrationTestBase.java
+++ b/gazeplay/src/integrationTest/java/net/gazeplay/IntegrationTestBase.java
@@ -1,0 +1,19 @@
+package net.gazeplay;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.testfx.framework.junit5.ApplicationTest;
+
+public class IntegrationTestBase extends ApplicationTest {
+
+    @BeforeAll
+    public static void setupHeadlessMode() {
+        if (Boolean.getBoolean("headless")) {
+            System.setProperty("testfx.robot", "glass");
+            System.setProperty("testfx.headless", "true");
+            System.setProperty("prism.order", "sw");
+            System.setProperty("prism.text", "t2k");
+            System.setProperty("java.awt.headless", "true");
+            System.setProperty("headless.geometry", "1920x1080-32");
+        }
+    }
+}

--- a/gazeplay/src/integrationTest/java/net/gazeplay/commons/utils/BravoIntegrationTest.java
+++ b/gazeplay/src/integrationTest/java/net/gazeplay/commons/utils/BravoIntegrationTest.java
@@ -14,7 +14,9 @@ import javafx.stage.Stage;
 import javafx.stage.WindowEvent;
 import lombok.extern.slf4j.Slf4j;
 import net.gazeplay.GamePanelDimensionProvider;
+import net.gazeplay.IntegrationTestBase;
 import net.gazeplay.ui.scenes.ingame.GameContext;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -34,9 +36,9 @@ import static junit.framework.TestCase.assertTrue;
 import static org.mockito.Mockito.when;
 
 @Slf4j
-@ExtendWith(ApplicationExtension.class)
 @RunWith(MockitoJUnitRunner.class)
-public class BravoTest {
+@ExtendWith(ApplicationExtension.class)
+public class BravoIntegrationTest {
 
     @Mock
     private GameContext mockGameContext;

--- a/gazeplay/src/integrationTest/java/net/gazeplay/latestnews/LatestNewsPopupIntegrationTest.java
+++ b/gazeplay/src/integrationTest/java/net/gazeplay/latestnews/LatestNewsPopupIntegrationTest.java
@@ -1,0 +1,59 @@
+package net.gazeplay.latestnews;
+
+import javafx.application.Application;
+import javafx.geometry.Dimension2D;
+import javafx.stage.Stage;
+import net.gazeplay.IntegrationTestBase;
+import net.gazeplay.commons.configuration.ActiveConfigurationContext;
+import net.gazeplay.commons.configuration.Configuration;
+import net.gazeplay.commons.ui.DefaultTranslator;
+import net.gazeplay.commons.ui.Translator;
+import net.gazeplay.commons.utils.CustomButton;
+import net.gazeplay.commons.utils.multilinguism.Multilinguism;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class LatestNewsPopupIntegrationTest extends IntegrationTestBase {
+
+    @BeforeEach
+    void setUpClass() throws Exception {
+        launch(TestApp.class);
+    }
+
+    @Override
+    public void start(Stage stage) {
+        stage.show();
+    }
+
+    @Test
+    void shouldBeNamedGazePlayNews() {
+        assertEquals("GazePlay News", ((Stage) listWindows().get(0)).getTitle());
+    }
+
+    @Test
+    void shouldCloseOnContinue() {
+        CustomButton continueButton = (CustomButton) lookup("#continue").queryAll().iterator().next();
+        clickOn(continueButton);
+        assertEquals(0, listWindows().size());
+    }
+
+    public static class TestApp extends Application {
+
+        @Override
+        public void start(Stage primaryStage) {
+            Configuration configuration = ActiveConfigurationContext.getInstance();
+            Translator translator = new DefaultTranslator(configuration, Multilinguism.getForResource("data/multilinguism/multilinguism.csv"));
+
+            LatestNewsPopup popup = new LatestNewsPopup(
+                configuration,
+                translator,
+                () -> new Dimension2D(1920, 1080)
+            );
+
+            popup.show();
+            primaryStage.close(); // Ensures only one window is open.
+        }
+    }
+}

--- a/gazeplay/src/main/java/net/gazeplay/latestnews/LatestNewsPopup.java
+++ b/gazeplay/src/main/java/net/gazeplay/latestnews/LatestNewsPopup.java
@@ -139,6 +139,7 @@ public class LatestNewsPopup {
         Dimension2D screenDimension = screenDimensionSupplier.get();
 
         CustomButton continueButton = new CustomButton("data/common/images/continue.png", screenDimension);
+        continueButton.setId("continue");
 
         topPane.getChildren().addAll(userAgentLabel, locationUrlLabel);
         bottomPane.getChildren().addAll(closeInstructionLabel, continueButton);
@@ -214,6 +215,10 @@ public class LatestNewsPopup {
 
     private void showAndWait() {
         stage.showAndWait();
+    }
+
+    void show() {
+        stage.show();
     }
 
     String getOfflinePageContent() {

--- a/gazeplay/src/test/java/net/gazeplay/ui/MusicControlTest.java
+++ b/gazeplay/src/test/java/net/gazeplay/ui/MusicControlTest.java
@@ -1,10 +1,13 @@
 package net.gazeplay.ui;
 
+import javafx.beans.property.SimpleBooleanProperty;
 import javafx.scene.control.Button;
 import javafx.scene.control.Slider;
 import javafx.scene.layout.StackPane;
+import mockit.MockUp;
 import net.gazeplay.GazePlay;
 import net.gazeplay.commons.ui.Translator;
+import net.gazeplay.commons.utils.games.BackgroundMusicManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -17,8 +20,8 @@ import org.testfx.framework.junit5.ApplicationExtension;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
 
-@ExtendWith(ApplicationExtension.class)
 @RunWith(MockitoJUnitRunner.class)
+@ExtendWith(ApplicationExtension.class)
 class MusicControlTest {
 
     @Mock
@@ -26,6 +29,9 @@ class MusicControlTest {
 
     @Mock
     Translator mockTranslator;
+
+    @Mock
+    BackgroundMusicManager mockMusicManager;
 
     Slider mockVolumeSlider;
 
@@ -40,9 +46,18 @@ class MusicControlTest {
     }
 
     void initMocks() {
+        new MockUp<BackgroundMusicManager>() {
+            @mockit.Mock
+            public BackgroundMusicManager getInstance() {
+                return mockMusicManager;
+            }
+        };
+
         MockitoAnnotations.initMocks(this);
         when(mockGazePlay.getTranslator()).thenReturn(mockTranslator);
         when(mockTranslator.translate()).thenReturn("translation");
+        when(mockMusicManager.getIsMusicChanging()).thenReturn(new SimpleBooleanProperty(false));
+        when(mockMusicManager.getIsPlayingProperty()).thenReturn(new SimpleBooleanProperty(false));
     }
 
     @Test

--- a/gradle/integration.gradle
+++ b/gradle/integration.gradle
@@ -1,4 +1,4 @@
-task integrationTest(type: Test) {
+task integrationTest(type: Test, group: "verification") {
     useJUnitPlatform()
     testClassesDirs = sourceSets.integrationTest.output.classesDirs
     classpath = sourceSets.integrationTest.runtimeClasspath


### PR DESCRIPTION
Previously I introduced the `integrationTest` task into Gradle, but at the time I struggled to make anything work. Now I have an example test that runs headlessly on both a dev machine and in CI. It's not an end-to-end test, but it shows how to use the FxRobot to click on buttons visually. 
If a dev wants to see the tests running on their machine (while losing control of their mouse) they can add `-Pheadless=false` to the Gradle command line. 

I also fixed up the tests that has to be excluded from CI since they tried to play music. Now I have a better understanding of mocking, I was able to bypass using that JavaFX class and just test the functionality as a good unit test should.