### PR TITLE
Extracting the inner folder from downloaded JREs

### DIFF
--- a/gradle/jre/linux.gradle
+++ b/gradle/jre/linux.gradle
@@ -18,12 +18,15 @@ task extractLinuxJRE(dependsOn: downloadLinuxJRE, type: Copy, group: 'custom jre
     into "${jreFolder}/linux-x64"
 }
 
-task removeEnclosingFolderLinux(type: Delete, group: 'custom jre') {
-    delete "${jreFolder}/linux-x64/${filename}"
-}
+task downloadAndExtractLinuxJRE(dependsOn: extractLinuxJRE, group: 'custom jre') {
+    doLast {
+        copy {
+            from new File(extractLinuxJRE.getDestinationDir(), filename)
+            into "${jreFolder}/linux-x64"
+        }
 
-task downloadAndExtractLinuxJRE(dependsOn: extractLinuxJRE, type: Copy, group: 'custom jre') {
-    from new File(extractLinuxJRE.getDestinationDir(), filename)
-    into "${jreFolder}/linux-x64"
-    finalizedBy removeEnclosingFolderLinux
+        delete {
+            "${jreFolder}/linux-x64/${filename}"
+        }
+    }
 }

--- a/gradle/jre/linux.gradle
+++ b/gradle/jre/linux.gradle
@@ -13,7 +13,17 @@ task downloadLinuxJRE(type: Download, group: 'custom jre') {
     overwrite false
 }
 
-task downloadAndExtractLinuxJRE(dependsOn: downloadLinuxJRE, type: Copy, group: 'custom jre') {
+task extractLinuxJRE(dependsOn: downloadLinuxJRE, type: Copy, group: 'custom jre') {
     from tarTree(downloadLinuxJRE.dest)
     into "${jreFolder}/linux-x64"
+}
+
+task removeEnclosingFolderLinux(type: Delete, group: 'custom jre') {
+    delete "${jreFolder}/linux-x64/${filename}"
+}
+
+task downloadAndExtractLinuxJRE(dependsOn: extractLinuxJRE, type: Copy, group: 'custom jre') {
+    from new File(extractLinuxJRE.getDestinationDir(), filename)
+    into "${jreFolder}/linux-x64"
+    finalizedBy removeEnclosingFolderLinux
 }

--- a/gradle/jre/macos.gradle
+++ b/gradle/jre/macos.gradle
@@ -18,12 +18,13 @@ task extractMacosJRE(dependsOn: downloadMacosJRE, type: Copy, group: 'custom jre
     into "${jreFolder}/macos"
 }
 
-task removeEnclosingFolderMacos(type: Delete, group: 'custom jre') {
-    delete "${jreFolder}/macos/${filename}"
-}
+task downloadAndExtractMacosJRE(dependsOn: extractMacosJRE, group: 'custom jre') {
+    doLast {
+        copy {
+            from new File(extractMacosJRE.getDestinationDir(), filename)
+            into "${jreFolder}/macos"
+        }
 
-task downloadAndExtractMacosJRE(dependsOn: extractMacosJRE, type: Copy, group: 'custom jre') {
-    from new File(extractMacosJRE.getDestinationDir(), filename)
-    into "${jreFolder}/macos"
-    finalizedBy removeEnclosingFolderMacos
+        delete "${jreFolder}/macos/${filename}"
+    }
 }

--- a/gradle/jre/macos.gradle
+++ b/gradle/jre/macos.gradle
@@ -13,7 +13,17 @@ task downloadMacosJRE(type: Download, group: 'custom jre') {
     overwrite false
 }
 
-task downloadAndExtractMacosJRE(dependsOn: downloadMacosJRE, type: Copy, group: 'custom jre') {
+task extractMacosJRE(dependsOn: downloadMacosJRE, type: Copy, group: 'custom jre') {
     from tarTree(downloadMacosJRE.dest)
     into "${jreFolder}/macos"
+}
+
+task removeEnclosingFolderMacos(type: Delete, group: 'custom jre') {
+    delete "${jreFolder}/macos/${filename}"
+}
+
+task downloadAndExtractMacosJRE(dependsOn: extractMacosJRE, type: Copy, group: 'custom jre') {
+    from new File(extractMacosJRE.getDestinationDir(), filename)
+    into "${jreFolder}/macos"
+    finalizedBy removeEnclosingFolderMacos
 }

--- a/gradle/jre/windows.gradle
+++ b/gradle/jre/windows.gradle
@@ -18,12 +18,13 @@ task extractWindowsJRE(dependsOn: downloadWindowsJRE, type: Copy, group: 'custom
     into "${jreFolder}/windows-x64"
 }
 
-task removeEnclosingFolderWindows(type: Delete, group: 'custom jre') {
-    delete "${jreFolder}/windows-x64/${x64filename}"
-}
+task downloadAndExtractWindowsJRE(dependsOn: extractWindowsJRE, group: 'custom jre') {
+    doLast {
+        copy {
+            from new File(extractWindowsJRE.getDestinationDir(), x64filename)
+            into "${jreFolder}/windows-x64"
+        }
 
-task downloadAndExtractWindowsJRE(dependsOn: extractWindowsJRE, type: Copy, group: 'custom jre') {
-    from new File(extractWindowsJRE.getDestinationDir(), x64filename)
-    into "${jreFolder}/windows-x64"
-    finalizedBy removeEnclosingFolderWindows
+        delete "${jreFolder}/windows-x64/${x64filename}"
+    }
 }

--- a/gradle/jre/windows.gradle
+++ b/gradle/jre/windows.gradle
@@ -13,7 +13,17 @@ task downloadWindowsJRE(type: Download, group: 'custom jre') {
     overwrite false
 }
 
-task downloadAndExtractWindowsJRE(dependsOn: downloadWindowsJRE, type: Copy, group: 'custom jre') {
+task extractWindowsJRE(dependsOn: downloadWindowsJRE, type: Copy, group: 'custom jre') {
     from zipTree(downloadWindowsJRE.dest)
     into "${jreFolder}/windows-x64"
+}
+
+task removeEnclosingFolderWindows(type: Delete, group: 'custom jre') {
+    delete "${jreFolder}/windows-x64/${x64filename}"
+}
+
+task downloadAndExtractWindowsJRE(dependsOn: extractWindowsJRE, type: Copy, group: 'custom jre') {
+    from new File(extractWindowsJRE.getDestinationDir(), x64filename)
+    into "${jreFolder}/windows-x64"
+    finalizedBy removeEnclosingFolderWindows
 }


### PR DESCRIPTION
Fixes #1130

The problem was that in the packaged download we weren't extracting the actual JRE files from the root folder. This fixes that with an extra task that performs this extraction and another that does a bit of tidying up.