### PR TITLE
fixing issue with progressBar bad if check in sliding puzzle game

### DIFF
--- a/gazeplay-games/src/main/java/net/gazeplay/games/slidingpuzzle/SlidingPuzzleCard.java
+++ b/gazeplay-games/src/main/java/net/gazeplay/games/slidingpuzzle/SlidingPuzzleCard.java
@@ -190,7 +190,6 @@ class SlidingPuzzleCard extends Parent {
         return e -> {
 
             if (!(currentTimeline.getStatus() == Animation.Status.RUNNING)
-                && (timelineProgressBar != null)
                 && (e.getEventType() == MouseEvent.MOUSE_ENTERED
                 || e.getEventType() == GazeEvent.GAZE_ENTERED) && checkIfNeighbor()) {
 


### PR DESCRIPTION
reverse useless check added for timelineProgressBar on gazeEnter making game unusable