### PR TITLE
PMD Problems - I18N and Languages

### DIFF
--- a/gazeplay-commons/src/main/java/net/gazeplay/commons/utils/multilinguism/I18N.java
+++ b/gazeplay-commons/src/main/java/net/gazeplay/commons/utils/multilinguism/I18N.java
@@ -6,6 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -32,7 +33,7 @@ public class I18N {
 
         if (new File(resourceLocation).isFile()) {
             try {
-                is = new FileInputStream(new File(resourceLocation));
+                is = Files.newInputStream(new File(resourceLocation).toPath());
             } catch (IOException ie) {
                 log.error("Exception while reading file {}", resourceLocation, ie);
                 throw new RuntimeException(ie);

--- a/gazeplay-commons/src/main/java/net/gazeplay/commons/utils/multilinguism/LanguageDetails.java
+++ b/gazeplay-commons/src/main/java/net/gazeplay/commons/utils/multilinguism/LanguageDetails.java
@@ -9,11 +9,15 @@ import java.util.Locale;
 @Builder
 public class LanguageDetails {
 
-    // the ISO 639 code of the language
+    /**
+     * The ISO 639 code of the language
+     */
     @Getter
     private final Locale locale;
 
-    // the language name
+    /**
+     * The language name
+     */
     @Getter
     private final String label;
 
@@ -23,7 +27,9 @@ public class LanguageDetails {
     @Getter
     private final boolean leftAligned;
 
-    // flags corresponding to this language
+    /**
+     * Flags corresponding to this language
+     */
     @Getter
     private final List<String> flags;
 

--- a/gazeplay-commons/src/main/java/net/gazeplay/commons/utils/multilinguism/Languages.java
+++ b/gazeplay-commons/src/main/java/net/gazeplay/commons/utils/multilinguism/Languages.java
@@ -109,17 +109,18 @@ public class Languages {
     }
 
     public static LanguageDetails getLocale(Locale locale) {
-        if (locale == null) {
-            locale = DEFAULT_CODE;
+        Locale result = locale;
+        if (result == null) {
+            result = DEFAULT_CODE;
         }
 
-        final LanguageDetails localeValue = languageMap.get(locale);
+        final LanguageDetails localeValue = languageMap.get(result);
 
         if (localeValue == null) {
-            locale = DEFAULT_CODE;
+            result = DEFAULT_CODE;
         }
 
-        return languageMap.get(locale);
+        return languageMap.get(result);
     }
 
     public static Collection<LanguageDetails> getAllLanguageDetails() {

--- a/gazeplay-commons/src/test/java/net/gazeplay/commons/utils/multilinguism/LanguagesTest.java
+++ b/gazeplay-commons/src/test/java/net/gazeplay/commons/utils/multilinguism/LanguagesTest.java
@@ -1,0 +1,56 @@
+package net.gazeplay.commons.utils.multilinguism;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LanguagesTest {
+
+    @Test
+    void shouldGetAllLanguageDetails() {
+        Collection<LanguageDetails> result = Languages.getAllLanguageDetails();
+        LanguageDetails gb = null;
+
+        for (LanguageDetails temp : result) {
+            if (temp.getLocale().equals(new Locale("eng", "GB"))) {
+                gb = temp;
+                break;
+            }
+        }
+
+        assertEquals(23, result.size());
+        assertEquals("English", gb.getLabel());
+        assertTrue(gb.getFlags().get(0).contains("Flag_of_the_United_Kingdom"));
+    }
+
+    @Test
+    void shouldGetAllCodes() {
+        Collection<Locale> result = Languages.getAllCodes();
+        assertEquals(23, result.size());
+    }
+
+    @Test
+    void shouldGetValidLocale() {
+        LanguageDetails result = Languages.getLocale(new Locale("eng", "GB"));
+        assertEquals("English", result.getLabel());
+        assertTrue(result.getFlags().get(0).contains("Flag_of_the_United_Kingdom"));
+    }
+
+    @Test
+    void shouldGetNullLocale() {
+        LanguageDetails result = Languages.getLocale(null);
+        assertEquals("Français", result.getLabel());
+        assertTrue(result.getFlags().get(0).contains("Flag_of_France"));
+    }
+
+    @Test
+    void shouldGetInvalidLocale() {
+        LanguageDetails result = Languages.getLocale(new Locale("invalid", "locale"));
+        assertEquals("Français", result.getLabel());
+        assertTrue(result.getFlags().get(0).contains("Flag_of_France"));
+    }
+}


### PR DESCRIPTION
### PMD Problems
`I18N` 
[AvoidFileStream](https://pmd.github.io/pmd-6.17.0/pmd_rules_java_performance.html#avoidfilestream) - line 35

`Languages`
[AvoidReassigningParameters](https://pmd.github.io/pmd-6.17.0/pmd_rules_java_bestpractices.html#avoidreassigningparameters) - line 111

### Solution
Changed to `Files.newFileStream` and added mid-method parameter.

### Extras
* 100% test coverage of Languages