### PR TITLE
Fixing CD-made installer

### DIFF
--- a/gradle/innosetup/setup.iss.skel
+++ b/gradle/innosetup/setup.iss.skel
@@ -43,7 +43,7 @@ Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{
 
 [Files]
 Source: "gazeplayicon.ico"; DestDir: "{app}\\bin"; Flags: ignoreversion
-Source: "..\\${unpackedDirectory}\\bin\\gazeplay-windows.bat"; DestDir: "{app}\\bin"; Flags: ignoreversion
+Source: "..\\${unpackedDirectory}\\bin\\*"; DestDir: "{app}\\bin"; Flags: ignoreversion
 Source: "..\\${unpackedDirectory}\\lib\\*"; DestDir: "{app}\\lib"; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "..\\${unpackedDirectory}\\license\\*"; DestDir: "{app}\\license"; Flags: ignoreversion recursesubdirs createallsubdirs
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files

--- a/gradle/installer.gradle
+++ b/gradle/installer.gradle
@@ -64,5 +64,6 @@ task prepareInnoSetupFiles(group: 'distribution') {
 task unzipDistribution(dependsOn: ['packageApp'], type: Copy, group: 'distribution') {
     from zipTree("${buildDir}/distributions/gazeplay-project-windows-x64-${version}.zip")
     into buildDir
-    fileMode 0755
+    fileMode 0777
+    dirMode 0777
 }


### PR DESCRIPTION
Fixes #1144 

The problem (since 7th Feb) was caused by the dirMode not being set on Unix, and that meant that the Docker container couldn't mount that directory, or InnoSetup couldn't access it. This has been fixed now, and testing in the GitHub Actions environment.