### PR TITLE
GitHub Actions for Releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,62 @@
+on:
+  push:
+    branches:
+      - master
+
+name: Release GazePlay
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: Setup Git Config
+        run: |
+          git config --global user.email "ci@gazeplay.net"
+          git config --global user.name "GazePlay Automation"
+      - name: Download JREs
+        run: |
+          ./gradlew --stacktrace --info downloadAndExtractJREs
+          chmod -R 777 build/jre
+      - name: Run Gradle Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ./gradlew --stacktrace --info release -Prelease.useAutomaticVersion=true
+
+      - name: Get Previous tag
+        id: previous-tag
+        uses: WyriHaximus/github-action-get-previous-tag@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create GitHub Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.previous-tag.outputs.tag }}
+          release_name: GazePlay ${{ steps.previous-tag.outputs.tag }}
+          draft: false
+          prerelease: false
+
+      - name: Upload Assets to Release
+        id: upload-assets
+        uses: csexton/release-asset-action@v2
+        with:
+          release-url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`.
+          files: |
+            ./build/distributions/gazeplay-linux-x64-${{ steps.previous-tag.outputs.tag }}.tar.gz
+            ./build/distributions/gazeplay-macos-${{ steps.previous-tag.outputs.tag }}.tar.gz
+            ./build/distributions/gazeplay-windows-x64-${{ steps.previous-tag.outputs.tag }}.zip
+            ./build/distributions/gazeplay-windows-x64-${{ steps.previous-tag.outputs.tag }}-installer.exe
+            ./build/distributions/gazeplay-no-jre-${{ steps.previous-tag.outputs.tag }}.tar.gz
+            ./build/distributions/gazeplay-no-jre-${{ steps.previous-tag.outputs.tag }}.zip
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/build.gradle
+++ b/build.gradle
@@ -248,4 +248,4 @@ mainClassName = 'net.gazeplay.GazePlayLauncher'
 defaultTasks 'clean', 'build', 'checkPMDReport'
 startScripts.enabled = false
 
-afterReleaseBuild.dependsOn generateWindowsInstaller
+afterReleaseBuild.dependsOn generateWindowsInstallerInDocker

--- a/gradle/innosetup/setup.iss.skel
+++ b/gradle/innosetup/setup.iss.skel
@@ -34,7 +34,7 @@ DefaultGroupName=GazePlay
 LicenseFile=licence.txt
 
 OutputDir=..\\distributions
-OutputBaseFilename=GazePlay-installer-${applicationVersion}-x64
+OutputBaseFilename=gazeplay-windows-x64-${applicationVersion}-installer
 ;Compression=lzma
 SolidCompression=yes
 

--- a/gradle/installer.gradle
+++ b/gradle/installer.gradle
@@ -34,7 +34,7 @@ task prepareInnoSetupFiles(group: 'distribution') {
             rename("setup.iss.skel", "setup.iss")
             expand([
                     applicationVersion: "${version}",
-                    unpackedDirectory : "gazeplay-project-windows-x64-${version}"
+                    unpackedDirectory : "${project.name}-windows-x64-${version}"
             ])
             into(innoSetupDir)
         }
@@ -62,7 +62,7 @@ task prepareInnoSetupFiles(group: 'distribution') {
 }
 
 task unzipDistribution(dependsOn: ['packageApp'], type: Copy, group: 'distribution') {
-    from zipTree("${buildDir}/distributions/gazeplay-project-windows-x64-${version}.zip")
+    from zipTree("${buildDir}/distributions/${project.name}-windows-x64-${version}.zip")
     into buildDir
     fileMode 0777
     dirMode 0777

--- a/gradle/package.gradle
+++ b/gradle/package.gradle
@@ -19,4 +19,8 @@ task scriptsForRelease(type: Copy, group: 'distribution') {
     outputs.upToDateWhen { false } // Forces the task to rerun every time, without requiring a clean.
 }
 
-beforeReleaseBuild.dependsOn packageApp
+task packageAppWithDistPermissions(dependsOn: packageApp, type: Exec, group: 'distribution') {
+    commandLine 'chmod', '-R', '777', "${rootDir}/build/distributions"
+}
+
+beforeReleaseBuild.dependsOn packageAppWithDistPermissions

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,7 +2,7 @@ plugins {
     id "com.gradle.enterprise" version "3.1.1"
 }
 
-rootProject.name = 'gazeplay-project'
+rootProject.name = 'gazeplay'
 include(':gazeplay-commons')
 include(':gazeplay-games-commons')
 include(':gazeplay-games')


### PR DESCRIPTION
This will help us on our way to simplifying releases.

This new action is set up to run whenever `develop` is merged into `master`. It will build the project with the release version number (which must be set before merging), create the GitHub release and upload all the necessary artifacts. 

I also made the naming conventions for everything uniform, including changing the project name from `gazeplay-project` to simply `gazeplay`.