### PR TITLE
Adding Artifact Upload to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,3 +19,9 @@ jobs:
         run: sudo apt-get install xvfb
       - name: Run tests with Gradle
         run: xvfb-run --auto-servernum ./gradlew --stacktrace --info test
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: 'Build Reports'
+          path: ./**/build/reports/
+


### PR DESCRIPTION
With this PR we can now download the Test Reports from any new CI Build
![image](https://user-images.githubusercontent.com/33665681/83968088-9da04380-a8be-11ea-92df-16526f17fcfa.png)
