### PR TITLE
Dice game light mode fixed #1474

### DIFF
--- a/gazeplay-core/src/main/java/net/gazeplay/ui/scenes/ingame/GameContextFactoryBean.java
+++ b/gazeplay-core/src/main/java/net/gazeplay/ui/scenes/ingame/GameContextFactoryBean.java
@@ -111,7 +111,7 @@ public class GameContextFactoryBean implements FactoryBean<GameContext> {
         Color color = config.getBackgroundStyle().accept(new BackgroundStyleVisitor<Color>() {
             @Override
             public Color visitLight() {
-                return Color.WHITE;
+                return Color.LIGHTGREY;
             }
 
             @Override

--- a/gazeplay-games/src/main/java/net/gazeplay/games/dice/Dice.java
+++ b/gazeplay-games/src/main/java/net/gazeplay/games/dice/Dice.java
@@ -15,6 +15,8 @@ import javafx.util.Duration;
 import lombok.extern.slf4j.Slf4j;
 import net.gazeplay.GameLifeCycle;
 import net.gazeplay.IGameContext;
+import net.gazeplay.commons.configuration.BackgroundStyle;
+import net.gazeplay.commons.configuration.Configuration;
 import net.gazeplay.commons.random.ReplayablePseudoRandom;
 import net.gazeplay.commons.utils.stats.Stats;
 import net.gazeplay.components.DiceRoller;
@@ -34,6 +36,7 @@ public class Dice implements GameLifeCycle {
     private boolean active;
     private final int[] rolls;
     private final ProgressButton rollButton;
+    private final Configuration configuration;
 
     private final ReplayablePseudoRandom randomGenerator;
 
@@ -43,6 +46,7 @@ public class Dice implements GameLifeCycle {
         this.randomGenerator = new ReplayablePseudoRandom();
         this.stats.setGameSeed(randomGenerator.getSeed());
         final Dimension2D dimensions = gameContext.getGamePanelDimensionProvider().getDimension2D();
+        this.configuration = gameContext.getConfiguration();
         active = true;
 
         rolls = new int[nbDice];
@@ -70,7 +74,12 @@ public class Dice implements GameLifeCycle {
 
         totalText = new Text(0, dimensions.getHeight() / 5, "");
         totalText.setTextAlignment(TextAlignment.CENTER);
-        totalText.setFill(Color.WHITE);
+
+        if (configuration.getBackgroundStyle() == BackgroundStyle.DARK)
+            totalText.setFill(Color.WHITE);
+        else
+            totalText.setFill(Color.BLACK);
+
         totalText.setFont(new Font(dimensions.getHeight() / 4));
         totalText.setWrappingWidth(dimensions.getWidth());
 
@@ -106,6 +115,7 @@ public class Dice implements GameLifeCycle {
         this.randomGenerator = new ReplayablePseudoRandom(gameSeed);
         final Dimension2D dimensions = gameContext.getGamePanelDimensionProvider().getDimension2D();
         active = true;
+        this.configuration = gameContext.getConfiguration();
 
         rolls = new int[nbDice];
 
@@ -132,7 +142,12 @@ public class Dice implements GameLifeCycle {
 
         totalText = new Text(0, dimensions.getHeight() / 5, "");
         totalText.setTextAlignment(TextAlignment.CENTER);
-        totalText.setFill(Color.WHITE);
+
+        if (configuration.getBackgroundStyle() == BackgroundStyle.DARK)
+            totalText.setFill(Color.WHITE);
+        else
+            totalText.setFill(Color.BLACK);
+
         totalText.setFont(new Font(dimensions.getHeight() / 4));
         totalText.setWrappingWidth(dimensions.getWidth());
 

--- a/gazeplay-games/src/main/java/net/gazeplay/games/dice/Dice.java
+++ b/gazeplay-games/src/main/java/net/gazeplay/games/dice/Dice.java
@@ -145,8 +145,10 @@ public class Dice implements GameLifeCycle {
 
         if (configuration.getBackgroundStyle() == BackgroundStyle.DARK)
             totalText.setFill(Color.WHITE);
-        else
+        else {
             totalText.setFill(Color.BLACK);
+            //gameContext.getConfiguration().setBackgroundStyle(BackgroundStyle.GRAY);
+        }
 
         totalText.setFont(new Font(dimensions.getHeight() / 4));
         totalText.setWrappingWidth(dimensions.getWidth());

--- a/gazeplay-games/src/main/java/net/gazeplay/games/dice/Dice.java
+++ b/gazeplay-games/src/main/java/net/gazeplay/games/dice/Dice.java
@@ -15,7 +15,7 @@ import javafx.util.Duration;
 import lombok.extern.slf4j.Slf4j;
 import net.gazeplay.GameLifeCycle;
 import net.gazeplay.IGameContext;
-import net.gazeplay.commons.configuration.BackgroundStyle;
+import net.gazeplay.commons.configuration.BackgroundStyleVisitor;
 import net.gazeplay.commons.configuration.Configuration;
 import net.gazeplay.commons.random.ReplayablePseudoRandom;
 import net.gazeplay.commons.utils.stats.Stats;
@@ -75,10 +75,19 @@ public class Dice implements GameLifeCycle {
         totalText = new Text(0, dimensions.getHeight() / 5, "");
         totalText.setTextAlignment(TextAlignment.CENTER);
 
-        if (configuration.getBackgroundStyle() == BackgroundStyle.DARK)
-            totalText.setFill(Color.WHITE);
-        else
-            totalText.setFill(Color.BLACK);
+        Color color = configuration.getBackgroundStyle().accept(new BackgroundStyleVisitor<Color>() {
+            @Override
+            public Color visitLight() {
+                return Color.BLACK;
+            }
+
+            @Override
+            public Color visitDark() {
+                return Color.WHITE;
+            }
+        });
+
+        totalText.setFill(color);
 
         totalText.setFont(new Font(dimensions.getHeight() / 4));
         totalText.setWrappingWidth(dimensions.getWidth());
@@ -143,12 +152,20 @@ public class Dice implements GameLifeCycle {
         totalText = new Text(0, dimensions.getHeight() / 5, "");
         totalText.setTextAlignment(TextAlignment.CENTER);
 
-        if (configuration.getBackgroundStyle() == BackgroundStyle.DARK)
-            totalText.setFill(Color.WHITE);
-        else {
-            totalText.setFill(Color.BLACK);
-            //gameContext.getConfiguration().setBackgroundStyle(BackgroundStyle.GRAY);
-        }
+        Color color = configuration.getBackgroundStyle().accept(new BackgroundStyleVisitor<Color>() {
+            @Override
+            public Color visitLight() {
+                return Color.BLACK;
+            }
+
+            @Override
+            public Color visitDark() {
+                return Color.WHITE;
+            }
+        });
+
+        totalText.setFill(color);
+
 
         totalText.setFont(new Font(dimensions.getHeight() / 4));
         totalText.setWrappingWidth(dimensions.getWidth());


### PR DESCRIPTION
- It was impossible to see the value on the dice in the light mode, now fixed.

- FIxed #1474, I suggested changing the background color from white to light grey in the light mode .-. Seems like it works in other games too