### PR TITLE
Screenshot fixes

### DIFF
--- a/gazeplay-commons/src/main/java/net/gazeplay/commons/utils/stats/Stats.java
+++ b/gazeplay-commons/src/main/java/net/gazeplay/commons/utils/stats/Stats.java
@@ -937,7 +937,9 @@ public class Stats implements GazeMotionListener {
     }
 
     public void takeScreenShot() {
-        gameScreenShot = gameContextScene.snapshot(null);
+        if (!inReplayMode) {
+            gameScreenShot = gameContextScene.snapshot(null);
+        }
     }
 
     private JsonObject buildSavedDataJSON(JsonArray data) {

--- a/gazeplay-games/src/main/java/net/gazeplay/games/bubbles/Bubble.java
+++ b/gazeplay-games/src/main/java/net/gazeplay/games/bubbles/Bubble.java
@@ -58,7 +58,7 @@ public class Bubble implements GameLifeCycle {
         if (useBackgroundImage && gameContext.getConfiguration().isBackgroundEnabled()) {
             Dimension2D dimension2D = gameContext.getGamePanelDimensionProvider().getDimension2D();
             Rectangle imageRectangle = new Rectangle(0, 0, dimension2D.getWidth(), dimension2D.getHeight());
-            double imageRectangleOpacity = gameContext.getConfiguration().getBackgroundStyle().accept(new BackgroundStyleVisitor<Double>() {
+            double imageRectangleOpacity = gameContext.getConfiguration().getBackgroundStyle().accept(new BackgroundStyleVisitor<>() {
                 @Override
                 public Double visitLight() {
                     return 0.1;
@@ -72,15 +72,9 @@ public class Bubble implements GameLifeCycle {
 
             int randomWallpaperIndex = randomGenerator.nextInt(3);
             switch (randomWallpaperIndex) {
-                case 1:
-                    imageRectangle.setFill(new ImagePattern(new Image("data/bubble/images/inhabited-ocean.png")));
-                    break;
-                case 2:
-                    imageRectangle.setFill(new ImagePattern(new Image("data/bubble/images/empty-ocean.png")));
-                    break;
-                default:
-                    imageRectangle.setFill(new ImagePattern(new Image("data/bubble/images/underwater-treasures.jpg")));
-                    break;
+                case 1 -> imageRectangle.setFill(new ImagePattern(new Image("data/bubble/images/inhabited-ocean.png")));
+                case 2 -> imageRectangle.setFill(new ImagePattern(new Image("data/bubble/images/empty-ocean.png")));
+                default -> imageRectangle.setFill(new ImagePattern(new Image("data/bubble/images/underwater-treasures.jpg")));
             }
             imageRectangle.setOpacity(imageRectangleOpacity);
 

--- a/gazeplay-games/src/main/java/net/gazeplay/games/bubbles/Target.java
+++ b/gazeplay-games/src/main/java/net/gazeplay/games/bubbles/Target.java
@@ -122,10 +122,7 @@ public class Target extends ProgressPortrait {
     }
 
     private EventHandler<Event> buildEvent() {
-
-        return e -> {
-            enter(e);
-        };
+        return this::enter;
     }
 
     private List<Circle> buildFragments(final BubbleType bubbleType) {
@@ -153,12 +150,12 @@ public class Target extends ProgressPortrait {
     }
 
     public void explose() {
+        stats.takeScreenShot();
 
         final Timeline goToCenterTimeline = new Timeline();
         final Timeline timeline = new Timeline();
 
         for (int i = 0; i < nbFragments; i++) {
-
             final Circle fragment = fragments.get(i);
 
             Position curentPosition = getCurrentCenterPositionWithTranslation();
@@ -291,9 +288,7 @@ public class Target extends ProgressPortrait {
         }
 
         if (this.gameVariant != BubblesGameVariant.FIX) {
-            timeline.setOnFinished(e -> {
-                moveTarget();
-            });
+            timeline.setOnFinished(e -> moveTarget());
         }
 
         setLayoutX(centerX);

--- a/gazeplay-games/src/main/java/net/gazeplay/games/flowerOfNumbers/FlowerOfNumbersGame.java
+++ b/gazeplay-games/src/main/java/net/gazeplay/games/flowerOfNumbers/FlowerOfNumbersGame.java
@@ -264,6 +264,7 @@ public class FlowerOfNumbersGame implements GameLifeCycle {
             timeline.setOnFinished(timelineEvent -> {
                 newButton.layoutXProperty().bind(widthProperty.multiply(newX).subtract(newView.fitWidthProperty().divide(2)));
                 newButton.layoutYProperty().bind(heightProperty.multiply(newY).subtract(newView.fitHeightProperty().divide(2)));
+                stats.takeScreenShot();
 
                 checkIfPetalIsComplete(petal);
                 if (!checkIfFlowerIsComplete(false, true)) {
@@ -279,6 +280,7 @@ public class FlowerOfNumbersGame implements GameLifeCycle {
 
                         gameContext.getGazeDeviceManager().removeEventFilter(newButton);
                         gameContext.getChildren().remove(newButton);
+                        stats.takeScreenShot();
                     }, gameContext);
                     gameContext.getGazeDeviceManager().addEventFilter(newButton);
                     newButton.active();

--- a/gazeplay-games/src/main/java/net/gazeplay/games/flowerOfNumbers/FlowerOfNumbersGameLauncher.java
+++ b/gazeplay-games/src/main/java/net/gazeplay/games/flowerOfNumbers/FlowerOfNumbersGameLauncher.java
@@ -14,7 +14,7 @@ import net.gazeplay.commons.utils.stats.Stats;
 import java.util.ArrayList;
 import java.util.LinkedList;
 
-public class FlowerOfNumbersGameLauncher  implements IGameLauncher<Stats, IGameVariant> {
+public class FlowerOfNumbersGameLauncher implements IGameLauncher<Stats, IGameVariant> {
     @Override
     public Stats createNewStats(Scene scene) {
         return new Stats(scene, "FlowerOfNumbers");


### PR DESCRIPTION
fix #1575
Bubbles now appear on screenshots of Bubbles games.
Numerical items now appear on screenshots of the Flower of Numbers game.
Screenshot are no longer unnecessarily taken in replay mode.