### PR TITLE
Avoid switch fallthrough

### DIFF
--- a/gazeplay-games/src/main/java/net/gazeplay/games/bubbles/Bubble.java
+++ b/gazeplay-games/src/main/java/net/gazeplay/games/bubbles/Bubble.java
@@ -72,7 +72,9 @@ public class Bubble implements GameLifeCycle {
             int randomWallpaperIndex = randomGenerator.nextInt(3);
             switch (randomWallpaperIndex) {
                 case 1 -> imageRectangle.setFill(new ImagePattern(new Image("data/bubble/images/inhabited-ocean.png")));
+                    break;
                 case 2 -> imageRectangle.setFill(new ImagePattern(new Image("data/bubble/images/empty-ocean.png")));
+                    break;
                 default -> imageRectangle.setFill(new ImagePattern(new Image("data/bubble/images/underwater-treasures.jpg")));
             }
             imageRectangle.setOpacity(imageRectangleOpacity);


### PR DESCRIPTION
Added break statements to the switch on line 73 to prevent switch fallthrough pursuant to my own created issue #1660 (https://github.com/GazePlay/GazePlay/issues/1660), in-case the switch handling was not intentionally missing break statements or brackets.